### PR TITLE
修复 label 和 . 的问题

### DIFF
--- a/sinks/dingtalk/dingtalk.go
+++ b/sinks/dingtalk/dingtalk.go
@@ -184,8 +184,12 @@ func createMsgFromEvent(d *DingTalkSink, event *v1.Event) *DingTalkMsg {
 	case MARKDOWN_MSG_TYPE:
 		markdownCreator := NewMarkdownMsgBuilder(d.ClusterID, d.Region, event)
 		msg.Markdown = DingTalkMarkdown{
+			//title 加不加其实没所谓,最终不会显示
 			Title: fmt.Sprintf("Kubernetes(ID:%s) Event", d.ClusterID),
 			Text:  markdownCreator.Build(),
+		}
+		if d.Labels != nil && len(d.Labels) > 0 {
+			markdownCreator.AddLabels(d.Labels)
 		}
 		break
 

--- a/sinks/dingtalk/dingtalk.go
+++ b/sinks/dingtalk/dingtalk.go
@@ -183,14 +183,14 @@ func createMsgFromEvent(d *DingTalkSink, event *v1.Event) *DingTalkMsg {
 	//https://open-doc.dingtalk.com/microapp/serverapi2/ye8tup#-6
 	case MARKDOWN_MSG_TYPE:
 		markdownCreator := NewMarkdownMsgBuilder(d.ClusterID, d.Region, event)
+		if d.Labels != nil && len(d.Labels) > 0 {
+			markdownCreator.AddLabels(d.Labels)
+		}
 		msg.Markdown = DingTalkMarkdown{
 			//title 加不加其实没所谓,最终不会显示
 			Title: fmt.Sprintf("Kubernetes(ID:%s) Event", d.ClusterID),
 			Text:  markdownCreator.Build(),
-		}
-		if d.Labels != nil && len(d.Labels) > 0 {
-			markdownCreator.AddLabels(d.Labels)
-		}
+		}		
 		break
 
 	default:

--- a/sinks/dingtalk/markdownMsgBuilder.go
+++ b/sinks/dingtalk/markdownMsgBuilder.go
@@ -63,10 +63,10 @@ func NewMarkdownMsgBuilder(clusterID, region string, event *v1.Event) *MarkdownM
 		break
 	case "Service":
 		svcUrl := fmt.Sprintf(URL_ALIYUN_SVC_TEMPLATE, m.Region, m.ClusterID, event.Namespace, event.Name)
-		svcname := event.Name
-		//这里的event.Name 为 <svc_name>.xxxxx 需要截取处理掉.后面那部分内容,得到真正的  <svc_name>
+		serviceName := event.Name
+		//这里的event.Name 为 <service_name>.xxxxx 需要截取处理掉.后面那部分内容,得到真正的  <service_name>
 		if dotPosition := strings.Index(event.Name, "."); dotPosition > -1 {
-			svcname = event.Name[:dotPosition]
+			serviceName = event.Name[:dotPosition]
 		}
 		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, svcname, svcUrl)
 		break

--- a/sinks/dingtalk/markdownMsgBuilder.go
+++ b/sinks/dingtalk/markdownMsgBuilder.go
@@ -3,6 +3,7 @@ package dingtalk
 import (
 	"fmt"
 	"k8s.io/api/core/v1"
+	"strings"
 )
 
 const (
@@ -16,6 +17,7 @@ const (
 	URL_ALIYUN_RESOURCE_DETAIL_TEMPLATE = URL_ALIYUN_K8S_CONSULE + "/%s/detail/%s/%s/%s/%s/pods"
 	URL_ALIYUN_POD_TEMPLATE             = URL_ALIYUN_K8S_CONSULE + "/pod/%s/%s/%s/container"
 	URL_ALIYUN_CROBJOB_TEMPLATE         = URL_ALIYUN_K8S_CONSULE + "/cronjob/detail/%s/%s/%s/%s/jobs"
+	URL_ALIYUN_SVC_TEMPLATE             = URL_ALIYUN_K8S_CONSULE + "/service/detail/%s/%s/%s/%s"
 	URL_ALIYUN_NAMESPACE_TEMPLATE       = URL_ALIYUN_K8S_CONSULE + "/namespace"
 )
 
@@ -60,10 +62,10 @@ func NewMarkdownMsgBuilder(clusterID, region string, event *v1.Event) *MarkdownM
 		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, jobUrl)
 		break
 	case "Service":
-		svcUrl := fmt.Sprintf("%s/service/detail/%s/%s/%s/%s", URL_ALIYUN_K8S_CONSULE, m.Region, m.ClusterID, event.Namespace, event.Name)
+		svcUrl := fmt.Sprintf(URL_ALIYUN_SVC_TEMPLATE, m.Region, m.ClusterID, event.Namespace, event.Name)
 		svcname := event.Name
 		//这里的event.Name 为 <svc_name>.xxxxx 需要截取处理掉.后面那部分内容,得到真正的  <svc_name>
-		if dotPosition := s[:strings.Index(s, ".")]; dotPosition > -1 {
+		if dotPosition := strings.Index(event.Name, "."); dotPosition > -1 {
 			svcname = event.Name[:dotPosition]
 		}
 		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, svcname, svcUrl)

--- a/sinks/dingtalk/markdownMsgBuilder.go
+++ b/sinks/dingtalk/markdownMsgBuilder.go
@@ -42,33 +42,34 @@ func NewMarkdownMsgBuilder(clusterID, region string, event *v1.Event) *MarkdownM
 
 	switch event.InvolvedObject.Kind {
 	case "Deployment":
-		podsUrl := fmt.Sprintf(URL_ALIYUN_RESOURCE_DETAIL_TEMPLATE, "deployment", m.Region, m.ClusterID, event.Namespace, event.Name)
-		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, podsUrl)
+		deployName := removeDotContent(event.Name)
+		podsURL := fmt.Sprintf(URL_ALIYUN_RESOURCE_DETAIL_TEMPLATE, "deployment", m.Region, m.ClusterID, event.Namespace, deployName)
+		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, podsURL)
 		break
 	case "Pod":
-		podsUrl := fmt.Sprintf(URL_ALIYUN_POD_TEMPLATE, m.ClusterID, event.Namespace, event.Name)
-		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, podsUrl)
+		podName := removeDotContent(event.Name)
+		podsURL := fmt.Sprintf(URL_ALIYUN_POD_TEMPLATE, m.ClusterID, event.Namespace, podName)
+		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, podsURL)
 		break
 	case "StatefulSet":
-		podsUrl := fmt.Sprintf(URL_ALIYUN_RESOURCE_DETAIL_TEMPLATE, "statefulset", m.Region, m.ClusterID, event.Namespace, event.Name)
-		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, podsUrl)
+		ssName := removeDotContent(event.Name)
+		podsURL := fmt.Sprintf(URL_ALIYUN_RESOURCE_DETAIL_TEMPLATE, "statefulset", m.Region, m.ClusterID, event.Namespace, ssName)
+		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, podsURL)
 		break
 	case "DaemonSet":
-		podsUrl := fmt.Sprintf(URL_ALIYUN_RESOURCE_DETAIL_TEMPLATE, "daemonset", m.Region, m.ClusterID, event.Namespace, event.Name)
-		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, podsUrl)
+		dsName := removeDotContent(event.Name)
+		podsURL := fmt.Sprintf(URL_ALIYUN_RESOURCE_DETAIL_TEMPLATE, "daemonset", m.Region, m.ClusterID, event.Namespace, dsName)
+		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, podsURL)
 		break
 	case "CronJob":
-		jobUrl := fmt.Sprintf(URL_ALIYUN_CROBJOB_TEMPLATE, m.Region, m.ClusterID, event.Namespace, event.Name)
-		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, jobUrl)
+		jobName := removeDotContent(event.Name)
+		jobURL := fmt.Sprintf(URL_ALIYUN_CROBJOB_TEMPLATE, m.Region, m.ClusterID, event.Namespace, jobName)
+		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, jobURL)
 		break
 	case "Service":
-		svcUrl := fmt.Sprintf(URL_ALIYUN_SVC_TEMPLATE, m.Region, m.ClusterID, event.Namespace, event.Name)
-		serviceName := event.Name
-		//这里的event.Name 为 <service_name>.xxxxx 需要截取处理掉.后面那部分内容,得到真正的  <service_name>
-		if dotPosition := strings.Index(event.Name, "."); dotPosition > -1 {
-			serviceName = event.Name[:dotPosition]
-		}
-		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, serviceName, svcUrl)
+		serviceName := removeDotContent(event.Name)
+		svcURL := fmt.Sprintf(URL_ALIYUN_SVC_TEMPLATE, m.Region, m.ClusterID, event.Namespace, serviceName)
+		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, svcURL)
 		break
 		//fixme:覆盖所有 event.InvolvedObject.Kind
 	default:
@@ -81,6 +82,14 @@ func NewMarkdownMsgBuilder(clusterID, region string, event *v1.Event) *MarkdownM
 	m.OutputText = fmt.Sprintf(MARKDOWN_TEMPLATE, level, kind, namespace, name, reason, timestamp, message)
 	return &m
 
+}
+
+// removeDotContent 每个事件由 <resource>.<hash> 组成,需要去掉.后面的部分,得到 <resource>
+func removeDotContent(s string) string {
+	if dotPosition := strings.Index(s, "."); dotPosition > -1 {
+		s = s[:dotPosition]
+	}
+	return s
 }
 
 func (m *MarkdownMsgBuilder) AddLabels(labels []string) {

--- a/sinks/dingtalk/markdownMsgBuilder.go
+++ b/sinks/dingtalk/markdownMsgBuilder.go
@@ -61,7 +61,12 @@ func NewMarkdownMsgBuilder(clusterID, region string, event *v1.Event) *MarkdownM
 		break
 	case "Service":
 		svcUrl := fmt.Sprintf("%s/service/detail/%s/%s/%s/%s", URL_ALIYUN_K8S_CONSULE, m.Region, m.ClusterID, event.Namespace, event.Name)
-		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, event.Name, svcUrl)
+		svcname := event.Name
+		//这里的event.Name 为 <svc_name>.xxxxx 需要截取处理掉.后面那部分内容,得到真正的  <svc_name>
+		if dotPosition := s[:strings.Index(s, ".")]; dotPosition > -1 {
+			svcname = event.Name[:dotPosition]
+		}
+		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, svcname, svcUrl)
 		break
 		//fixme:覆盖所有 event.InvolvedObject.Kind
 	default:

--- a/sinks/dingtalk/markdownMsgBuilder.go
+++ b/sinks/dingtalk/markdownMsgBuilder.go
@@ -68,7 +68,7 @@ func NewMarkdownMsgBuilder(clusterID, region string, event *v1.Event) *MarkdownM
 		if dotPosition := strings.Index(event.Name, "."); dotPosition > -1 {
 			serviceName = event.Name[:dotPosition]
 		}
-		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, svcname, svcUrl)
+		name = fmt.Sprintf(MARKDOWN_LINK_TEMPLATE, serviceName, svcUrl)
 		break
 		//fixme:覆盖所有 event.InvolvedObject.Kind
 	default:

--- a/sinks/dingtalk/markdownMsgBuilder_test.go
+++ b/sinks/dingtalk/markdownMsgBuilder_test.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+	"strings"
 	"time"
 )
 
@@ -90,6 +91,13 @@ func TestNewMarkdownMsgBuilder_Service(t *testing.T) {
 	t.Log(string(text))
 	assert.True(t, m != nil)
 }
+
+func TestRemoveDotContent(t *testing.T){
+	s :=removeDotContent("eventer.15b21c773eb1181a.sssss")
+	t.Log(s)
+	assert.True(t,!strings.ContainsAny(s,"."))
+}
+
 
 func createTestEvent() *v1.Event {
 	now := time.Now()


### PR DESCRIPTION
1. 之前的提交在 NewMarkdownMsgBuilder 的时候忘了调用 AddLabels 方法
1. kubernetes event.Name是 `<resource>.<hash>`  ,之前忘了去掉`.`后面的内容,导致生成的URL有问题.

还有,你们[阿里云的文档](https://help.aliyun.com/document_detail/92544.html?spm=5176.11065259.1996646101.searchclickresult.3681c0b30YKMMC) 里面的command是 `/eventer ...`
实际上,生成的文件是`kube-eventer` ,如果有新的release 发布,文档记得更新一下
