### PR TITLE
Adding support for namespace in Elastic Search index name

### DIFF
--- a/common/elasticsearch/elasticsearch.go
+++ b/common/elasticsearch/elasticsearch.go
@@ -41,10 +41,12 @@ type ElasticSearchService struct {
 }
 
 func (esSvc *ElasticSearchService) Index(date time.Time, namespace string) string {
+	dateStr := date.Format("2006.01.02")
 	if len(namespace) > 0 {
-		return date.Format(fmt.Sprintf("%s-%s-2006.01.02", esSvc.baseIndex, namespace))
+		return fmt.Sprintf("%s-%s-%s", esSvc.baseIndex, namespace, dateStr)
 	}
-	return date.Format(fmt.Sprintf("%s-2006.01.02", esSvc.baseIndex))
+	return fmt.Sprintf("%s-%s", esSvc.baseIndex, date)
+
 }
 func (esSvc *ElasticSearchService) IndexAlias(typeName string) string {
 	return fmt.Sprintf("%s-%s", esSvc.baseIndex, typeName)

--- a/common/mysql/mysql.go
+++ b/common/mysql/mysql.go
@@ -23,8 +23,8 @@ import (
 )
 
 type MysqlService struct {
-	db    *sql.DB
-	dsn   string
+	db  *sql.DB
+	dsn string
 }
 
 type MysqlKubeEventPoint struct {
@@ -59,8 +59,8 @@ func (mySvc MysqlService) SaveData(sinkData []interface{}) error {
 
 		ked := data.(MysqlKubeEventPoint)
 		klog.Infof("Begin Insert Mysql Data ...")
-		klog.Infof("Namespace: %s, Kind: %s, Name: %s, Type: %s, Reason: %s, Message: %s, EventID: %s, FirstOccurrenceTimestamp: %s, LastOccurrenceTimestamp: %s ", ked.Namespace, ked.Kind, ked.Name,ked.Type, ked.Reason, ked.Message, ked.EventID, ked.FirstOccurrenceTimestamp, ked.LastOccurrenceTimestamp)
-		_, err = stmtIns.Exec(ked.Namespace, ked.Kind, ked.Name,ked.Type, ked.Reason, ked.Message, ked.EventID, ked.FirstOccurrenceTimestamp, ked.LastOccurrenceTimestamp)
+		klog.Infof("Namespace: %s, Kind: %s, Name: %s, Type: %s, Reason: %s, Message: %s, EventID: %s, FirstOccurrenceTimestamp: %s, LastOccurrenceTimestamp: %s ", ked.Namespace, ked.Kind, ked.Name, ked.Type, ked.Reason, ked.Message, ked.EventID, ked.FirstOccurrenceTimestamp, ked.LastOccurrenceTimestamp)
+		_, err = stmtIns.Exec(ked.Namespace, ked.Kind, ked.Name, ked.Type, ked.Reason, ked.Message, ked.EventID, ked.FirstOccurrenceTimestamp, ked.LastOccurrenceTimestamp)
 		if err != nil {
 			klog.Errorf("failed to Prepare statement for inserting data ")
 			return err
@@ -77,7 +77,7 @@ func (mySvc MysqlService) FlushData() error {
 }
 
 func (mySvc MysqlService) CreateDatabase(name string) error {
- 	return nil
+	return nil
 }
 
 func (mySvc MysqlService) CloseDB() error {

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src/github.com/AliyunContainerService/kube-eventer
 RUN apt-get update -y && apt-get install gcc ca-certificates
 RUN make
 
-FROM golang:1.12.6 
+FROM alpine:3.10
 COPY --from=build-env /usr/local/go/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
 COPY --from=build-env /src/github.com/AliyunContainerService/kube-eventer/kube-eventer /
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src/github.com/AliyunContainerService/kube-eventer
 RUN apt-get update -y && apt-get install gcc ca-certificates
 RUN make
 
-FROM alpine:3.10
+FROM golang:1.12.6 
 COPY --from=build-env /usr/local/go/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
 COPY --from=build-env /src/github.com/AliyunContainerService/kube-eventer/kube-eventer /
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,7 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/sinks/elasticsearch/driver_test.go
+++ b/sinks/elasticsearch/driver_test.go
@@ -38,7 +38,7 @@ type fakeESSink struct {
 
 var FakeESSink fakeESSink
 
-func SaveDataIntoES_Stub(date time.Time, sinkData []interface{}) error {
+func SaveDataIntoES_Stub(date time.Time, namespace string, sinkData []interface{}) error {
 	for _, data := range sinkData {
 		jsonItems, err := json.Marshal(data)
 		if err != nil {

--- a/sinks/mysql/mysql.go
+++ b/sinks/mysql/mysql.go
@@ -28,14 +28,13 @@ import (
 type SaveDataFunc func(sinkData []interface{}) error
 
 type mysqlSink struct {
-	mysqlSvc *mysql_common.MysqlService
+	mysqlSvc  *mysql_common.MysqlService
 	saveData  SaveDataFunc
 	flushData func() error
-	closeDB func() error
+	closeDB   func() error
 	sync.RWMutex
-	uri  *url.URL
+	uri *url.URL
 }
-
 
 const (
 	// Maximum number of mysql Points to be sent in one batch.
@@ -54,7 +53,6 @@ func (sink *mysqlSink) createDatabase() error {
 
 	return nil
 }
-
 
 // Generate point value for event
 func getEventValue(event *kube_api.Event) (string, error) {


### PR DESCRIPTION
This change adds an option to append the namespace to the index name so that indexes are split by namespace.
This allows to handle larger scale, easier acls and in some cases easier queries.