### PR TITLE
Fixing bug while creating index name

### DIFF
--- a/common/elasticsearch/elasticsearch.go
+++ b/common/elasticsearch/elasticsearch.go
@@ -68,9 +68,9 @@ func (esSvc *ElasticSearchService) Index(date time.Time, namespace string) strin
 	if len(namespace) > 0 {
 		return fmt.Sprintf("%s-%s-%s", esSvc.baseIndex, namespace, dateStr)
 	}
-	return fmt.Sprintf("%s-%s", esSvc.baseIndex, date)
-
+	return fmt.Sprintf("%s-%s", esSvc.baseIndex, dateStr)
 }
+
 func (esSvc *ElasticSearchService) IndexAlias(typeName string) string {
 	return fmt.Sprintf("%s-%s", esSvc.baseIndex, typeName)
 }

--- a/common/elasticsearch/elasticsearch_test.go
+++ b/common/elasticsearch/elasticsearch_test.go
@@ -173,6 +173,30 @@ func TestCreateElasticSearchServiceWithIngestPipeline(t *testing.T) {
 
 }
 
+func TestIndexName(t *testing.T) {
+
+	esURI := "https://foo.com:9200?sniff=false&healthCheck=false"
+	url, err := url.Parse(esURI)
+	if err != nil {
+		t.Fatalf("Error when parsing URL: %s", err.Error())
+	}
+	esSvc, err := CreateElasticSearchService(url)
+	if err != nil {
+		t.Fatalf("Creating svc: %s", err.Error())
+	}
+	indexDate := time.Date(2000, 2, 1, 0, 0, 0, 0, time.UTC)
+	indexName := esSvc.Index(indexDate, "")
+	if indexName != "heapster-2000.02.01" {
+		t.Fatalf("Unexpected index name %s", indexName)
+	}
+
+	indexName = esSvc.Index(indexDate, "application")
+	if indexName != "heapster-application-2000.02.01" {
+		t.Fatalf("Unexpected index name %s", indexName)
+	}
+
+}
+
 func TestCreateElasticSearchServiceSingleDnsEntrypointV5(t *testing.T) {
 	clusterName := "sandbox"
 	esURI := fmt.Sprintf("https://foo.com:9200?"+


### PR DESCRIPTION
The wrong variable was used to generate the index name, fixed and added a test to prevent it in the future.
This should fix https://github.com/AliyunContainerService/kube-eventer/issues/39