### PR TITLE
add timezone support

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -6,10 +6,15 @@ WORKDIR /src/github.com/AliyunContainerService/kube-eventer
 RUN apt-get update -y && apt-get install gcc ca-certificates
 RUN make
 
+
 FROM alpine:3.10
-COPY --from=build-env /usr/local/go/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
+
 COPY --from=build-env /src/github.com/AliyunContainerService/kube-eventer/kube-eventer /
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+ENV TZ "Asia/Shanghai"
+RUN apk add --no-cache tzdata
+COPY deploy/entrypoint.sh /
 
 ENTRYPOINT ["/kube-eventer"]
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "$TZ" >  /etc/timezone
+cp /usr/share/zoneinfo/$TZ   /etc/localtime
+/kube-eventer "$@"

--- a/sinks/dingtalk/dingtalk.go
+++ b/sinks/dingtalk/dingtalk.go
@@ -35,6 +35,7 @@ const (
 	DEFAULT_MSG_TYPE      = "text"
 	CONTENT_TYPE_JSON     = "application/json"
 	LABE_TEMPLATE         = "%s\n"
+	TIME_FORMAT           = "2006-01-02 15:04:05"
 )
 
 var (
@@ -208,7 +209,7 @@ func createMsgFromEvent(d *DingTalkSink, event *v1.Event) *DingTalkMsg {
 		}
 
 		msg.Text = DingTalkText{
-			Content: fmt.Sprintf(template, event.Type, event.InvolvedObject.Kind, event.Namespace, event.Name, event.Reason, event.LastTimestamp.String(), event.Message),
+			Content: fmt.Sprintf(template, event.Type, event.InvolvedObject.Kind, event.Namespace, event.Name, event.Reason, event.LastTimestamp.Format(TIME_FORMAT), event.Message),
 		}
 		break
 	}

--- a/sinks/dingtalk/dingtalk_test.go
+++ b/sinks/dingtalk/dingtalk_test.go
@@ -10,7 +10,6 @@ import (
 	//"os"
 	"encoding/json"
 	"net/url"
-	// "time"
 )
 
 func TestGetLevel(t *testing.T) {


### PR DESCRIPTION
Add Timezone to dingtalk bot. You can change the default timezone with env `TZ` 
![image](https://user-images.githubusercontent.com/3116693/74100658-746be280-4b6c-11ea-80d6-e184c9fc9e32.png)
