### PR TITLE
[Proposal] Adds a source that uses events.k8s.io api instead of core

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -13,6 +13,10 @@ If you don't want to setup inClusterConfig, you can still use kube-eventer! To r
 
 	--source=kubernetes:http://<address-of-kubernetes-master>:<http-port>?inClusterConfig=false
 
+To use the events.k8s.io/v1beta1 api instead of core/v1 kubernetes source add the following flag instead:
+
+	--source=kubernetes-eventsapi:<KUBERNETES_MASTER>[?<KUBERNETES_OPTIONS>]
+	
 This requires the apiserver to be setup completely without auth, which can be done by binding the insecure port to all interfaces (see the apiserver `--insecure-bind-address` option) but *WARNING* be aware of the security repercussions. Only do this if you trust *EVERYONE* on your network. Or you can setup proxy with command `kubectl proxy --port=8080` in local when debugging kube-eventer.
 
 The following options are available:

--- a/sources/factory.go
+++ b/sources/factory.go
@@ -29,7 +29,10 @@ type SourceFactory struct {
 func (this *SourceFactory) Build(uri flags.Uri) (core.EventSource, error) {
 	switch uri.Key {
 	case "kubernetes":
-		src, err := kube.NewKubernetesSource(&uri.Val)
+		src, err := kube.NewKubernetesSource(&uri.Val, false)
+		return src, err
+	case "kubernetes-eventsapi":
+		src, err := kube.NewKubernetesSource(&uri.Val, true)
 		return src, err
 	default:
 		return nil, fmt.Errorf("Source not recognized: %s", uri.Key)


### PR DESCRIPTION
Due to tight coupling of the core/v1.Event, this change just coverts the
new object to the old object, it will not be used by default, but
if an user needs to use events.k8s.io/v1beta instead of core/v1
they can by changing the source from kubernetes to kubernetes-eventsapi.

This way we can support both existing users and the new api since the one
in core seems that will be deprecated.

We can work on refactor/decoupling core/v1.Event from the sinks afterwards