### PR TITLE
fix "sink not recognized" bug

### DIFF
--- a/docs/en/mysql-sink.md
+++ b/docs/en/mysql-sink.md
@@ -31,4 +31,4 @@ create table kube_event
 
 For example:
 
-    --sink="mysql:?root:transwarp@tcp(172.16.180.132:3306)/kube_event?charset=utf8"
+    --sink=mysql:?root:transwarp@tcp(172.16.180.132:3306)/kube_event?charset=utf8


### PR DESCRIPTION
--sink=mysql:?root:transwarp@tcp(172.16.180.132:3306)/kube_event?charset=utf8

=右面的值不能用双引号, 不然会出sink not recognized error