### PR TITLE
Adding error metrics for elasticsearch sink

### DIFF
--- a/common/elasticsearch/elastic2.go
+++ b/common/elasticsearch/elastic2.go
@@ -57,6 +57,7 @@ func NewEsClient2(config ElasticConfig, bulkWorkers int) (*Elastic2Wrapper, erro
 		Name("ElasticSearchWorker").
 		Workers(bulkWorkers).
 		After(bulkAfterCBV2).
+		Stats(true).
 		BulkActions(1000).               // commit if # requests >= 1000
 		BulkSize(2 << 20).               // commit if size of requests >= 2 MB
 		FlushInterval(10 * time.Second). // commit every 10s
@@ -98,6 +99,13 @@ func (es *Elastic2Wrapper) HasAlias(indexName string, aliasName string) (bool, e
 		return false, err
 	}
 	return aliases.Indices[indexName].HasAlias(aliasName), nil
+}
+
+func (es *Elastic2Wrapper) ErrorStats() int64 {
+	if es.bulkProcessor != nil {
+		return es.bulkProcessor.Stats().Failed
+	}
+	return 0
 }
 
 func (es *Elastic2Wrapper) AddBulkReq(index, typeName string, data interface{}) error {

--- a/common/elasticsearch/elastic5.go
+++ b/common/elasticsearch/elastic5.go
@@ -59,6 +59,7 @@ func NewEsClient5(config ElasticConfig, bulkWorkers int, pipeline string) (*Elas
 		Name("ElasticSearchWorker").
 		Workers(bulkWorkers).
 		After(bulkAfterCBV5).
+		Stats(true).
 		BulkActions(1000).               // commit if # requests >= 1000
 		BulkSize(2 << 20).               // commit if size of requests >= 2 MB
 		FlushInterval(10 * time.Second). // commit every 10s
@@ -100,6 +101,13 @@ func (es *Elastic5Wrapper) HasAlias(indexName string, aliasName string) (bool, e
 		return false, err
 	}
 	return aliases.Indices[indexName].HasAlias(aliasName), nil
+}
+
+func (es *Elastic5Wrapper) ErrorStats() int64 {
+	if es.bulkProcessor != nil {
+		return es.bulkProcessor.Stats().Failed
+	}
+	return 0
 }
 
 func (es *Elastic5Wrapper) AddBulkReq(index, typeName string, data interface{}) error {

--- a/common/elasticsearch/elastic6.go
+++ b/common/elasticsearch/elastic6.go
@@ -59,6 +59,7 @@ func NewEsClient6(config ElasticConfig, bulkWorkers int, pipeline string) (*Elas
 		Name("ElasticSearchWorker").
 		Workers(bulkWorkers).
 		After(bulkAfterCBV6).
+		Stats(true).
 		BulkActions(1000).               // commit if # requests >= 1000
 		BulkSize(2 << 20).               // commit if size of requests >= 2 MB
 		FlushInterval(10 * time.Second). // commit every 10s
@@ -100,6 +101,13 @@ func (es *Elastic6Wrapper) HasAlias(indexName string, aliasName string) (bool, e
 		return false, err
 	}
 	return aliases.Indices[indexName].HasAlias(aliasName), nil
+}
+
+func (es *Elastic6Wrapper) ErrorStats() int64 {
+	if es.bulkProcessor != nil {
+		return es.bulkProcessor.Stats().Failed
+	}
+	return 0
 }
 
 func (es *Elastic6Wrapper) AddBulkReq(index, typeName string, data interface{}) error {

--- a/common/elasticsearch/elastic7.go
+++ b/common/elasticsearch/elastic7.go
@@ -59,6 +59,7 @@ func NewEsClient7(config ElasticConfig, bulkWorkers int, pipeline string) (*Elas
 		Name("ElasticSearchWorker").
 		Workers(bulkWorkers).
 		After(bulkAfterCBV7).
+		Stats(true).
 		BulkActions(1000).               // commit if # requests >= 1000
 		BulkSize(2 << 20).               // commit if size of requests >= 2 MB
 		FlushInterval(10 * time.Second). // commit every 10s
@@ -100,6 +101,13 @@ func (es *Elastic7Wrapper) HasAlias(indexName string, aliasName string) (bool, e
 		return false, err
 	}
 	return aliases.Indices[indexName].HasAlias(aliasName), nil
+}
+
+func (es *Elastic7Wrapper) ErrorStats() int64 {
+	if es.bulkProcessor != nil {
+		return es.bulkProcessor.Stats().Failed
+	}
+	return 0
 }
 
 func (es *Elastic7Wrapper) AddBulkReq(index, typeName string, data interface{}) error {

--- a/common/elasticsearch/elasticsearch.go
+++ b/common/elasticsearch/elasticsearch.go
@@ -41,6 +41,7 @@ type elasticWrapper interface {
 	AddAlias(index string, alias string) (bool, error)
 	HasAlias(index string, alias string) (bool, error)
 	AddBulkReq(index, typeName string, data interface{}) error
+	ErrorStats() int64
 	FlushBulk() error
 }
 
@@ -76,6 +77,10 @@ func (esSvc *ElasticSearchService) IndexAlias(typeName string) string {
 
 func (esSvc *ElasticSearchService) FlushData() error {
 	return esSvc.EsClient.FlushBulk()
+}
+
+func (esSvc *ElasticSearchService) ErrorStats() int64 {
+	return esSvc.EsClient.ErrorStats()
 }
 
 // SaveDataIntoES save metrics and events to ES by using ES client

--- a/eventer.go
+++ b/eventer.go
@@ -121,6 +121,9 @@ func startHTTPServer() {
 func validateFlags() error {
 	var minFrequency = 5 * time.Second
 
+	if *argHealthzPort > 65534 {
+		return fmt.Errorf("invalid port supplied for healthz %d", *argHealthzPort)
+	}
 	if *argFrequency < minFrequency {
 		return fmt.Errorf("frequency needs to be no less than %s, supplied %s", minFrequency,
 			*argFrequency)


### PR DESCRIPTION
This change enables gathering stats from the bulk process and allows to read the failures into prometheus, that way, users can track how the data exporting goes.