### PR TITLE
fix sls interrupt and change travis ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
 # You don't need to test on very old versions of the Go compiler. It's the user's
 # responsibility to keep their compiler up to date.
 go:
+  - 1.14.x
+  - 1.13.x
   - 1.12.x
   - 1.11.x
 
@@ -25,7 +27,8 @@ git:
 
 # Don't email me the results of the test runs.
 notifications:
-  email: false
+  email:
+  - zhongwei.lzw@alibaba-inc.com
 
 # Anything in before_script that returns a nonzero exit code will flunk the
 # build and immediately stop. It's sorta like having set -e enabled in bash.
@@ -38,6 +41,7 @@ before_script:
 # .golangci.yml file at the top level of your repo.
 script:
 #  - golangci-lint run       # run a bunch of code checkers/linters in parallel
+  - ./hack/check_gofmt.sh
   - go test ./... -race -coverprofile=coverage.txt -covermode=atomic
   
 after_success:


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  Here are some tips for you: 
感谢你提交了 pull request ，一些 tips 供您参考：

-->

**What type of PR is this?**
**PR类型是什么？**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

**What this PR does / why we need it**:
**这个PR解决了什么问题**:
SLS Sink may interrupt with other sinks because the failure of addon token.

**Does this PR introduce a breaking change?**:
**PR带来的破坏性变更**:
none 


**Test/Final result**:
**测试/最终运行结果**:
```
?   	github.com/AliyunContainerService/kube-eventer	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/api	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/common/elasticsearch	0.020s
ok  	github.com/AliyunContainerService/kube-eventer/common/flags	0.046s
ok  	github.com/AliyunContainerService/kube-eventer/common/honeycomb	0.041s
?   	github.com/AliyunContainerService/kube-eventer/common/influxdb	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/kafka	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/kubernetes	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/common/librato	0.030s
?   	github.com/AliyunContainerService/kube-eventer/common/mysql	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/riemann	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/core	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/manager	4.568s
?   	github.com/AliyunContainerService/kube-eventer/metrics/core	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks	15.037s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/dingtalk	0.023s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/elasticsearch	0.022s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/honeycomb	0.026s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/influxdb	0.025s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/kafka	0.015s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/log	0.022s
?   	github.com/AliyunContainerService/kube-eventer/sinks/mysql	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks/riemann	0.017s
?   	github.com/AliyunContainerService/kube-eventer/sinks/sls	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks/wechat	0.016s
?   	github.com/AliyunContainerService/kube-eventer/sources	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/sources/kubernetes	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/util	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/version	[no test files]
```


