### PR TITLE
Feature/generic webhook

### DIFF
--- a/common/filters/filter.go
+++ b/common/filters/filter.go
@@ -19,4 +19,3 @@ func GetValues(o []string) []string {
 	}
 	return nil
 }
-

--- a/common/filters/generic_filter.go
+++ b/common/filters/generic_filter.go
@@ -2,9 +2,9 @@ package filters
 
 import (
 	"k8s.io/api/core/v1"
+	log "k8s.io/klog"
 	"reflect"
 	"regexp"
-	log "k8s.io/klog"
 )
 
 type GenericFilter struct {

--- a/common/filters/generic_filter_test.go
+++ b/common/filters/generic_filter_test.go
@@ -1,10 +1,10 @@
 package filters
 
 import (
-	"testing"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 var (

--- a/common/kubernetes/configs.go
+++ b/common/kubernetes/configs.go
@@ -21,11 +21,11 @@ import (
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kube_rest "k8s.io/client-go/rest"
+	"k8s.io/client-go/kubernetes"
 	kubeclient "k8s.io/client-go/kubernetes"
+	kube_rest "k8s.io/client-go/rest"
 	kubeClientCmd "k8s.io/client-go/tools/clientcmd"
 	kubeClientCmdApi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (

--- a/docs/en/webhook-sink.md
+++ b/docs/en/webhook-sink.md
@@ -1,0 +1,114 @@
+### webhook sink
+
+*This sink supports generic webhook and you can use this sink integrated with chatbot(DingTalk,Slack,BearChat and so on) and webhook services.
+To use the webhook sink add the following flag:
+
+	--sink=webhook:<WEBHOOK_URL>&level=<Normal or Warning, Warning default>
+
+The following options are available:
+* `level` - Level of event (optional. default: Warning. Options: Warning and Normal)
+* `namespaces` - Namespaces to filter (optional. default: all namespaces,use commas to separate multi namespaces, Regexp pattern support)
+* `kinds` - Kinds to filter (optional. default: all kinds,use commas to separate multi kinds. Options: Node,Pod and so on.)
+* `reason` - Reason to filter (optional. default: empty, Regexp pattern support). You can use multi reason field in query.
+* `method` - Method to send request (optional. default: GET)
+* `header` - Header in request (optional. default: empty). You can use multi header field in query.
+* `custom_body_configmap` - The configmap name of request body template. You can use Template to customize request body. (optional.)
+* `custom_body_configmap_namespace` -  The configmap namespace of request body template. (optional.)
+
+For example:
+
+   	--sink=webhook:https://oapi.dingtalk.com/robot/send?access_token=a5c19f3e02feba7bd5dfc22bfb04afa212359acfe86fd80eb159187097b7d014&level=Normal&namespaces=a,b&kinds=c,d&header=contentType=customContentType&header=customHeaderKey=customHeaderValue 
+
+#### custom_body_configmap pattern 
+The default request body template is below.     
+```$xslt
+{
+	"EventType": "{{ .Type }}",
+	"EventKind": "{{ .Kind }}"
+	"EventReason": "{{ .Reason }}",
+	"EventTime": "{{ .EventTime }}",
+	"EventMessage": "{{ .Message }}"
+}
+```
+`kube-eventer` will render template with event to sink. The event struct is below.   
+```$xslt
+type Event struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`
+
+	// The object that this event is about.
+	InvolvedObject ObjectReference `json:"involvedObject" protobuf:"bytes,2,opt,name=involvedObject"`
+
+	// This should be a short, machine understandable string that gives the reason
+	// for the transition into the object's current status.
+	// TODO: provide exact specification for format.
+	// +optional
+	Reason string `json:"reason,omitempty" protobuf:"bytes,3,opt,name=reason"`
+
+	// A human-readable description of the status of this operation.
+	// TODO: decide on maximum length.
+	// +optional
+	Message string `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
+
+	// The component reporting this event. Should be a short machine understandable string.
+	// +optional
+	Source EventSource `json:"source,omitempty" protobuf:"bytes,5,opt,name=source"`
+
+	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
+	// +optional
+	FirstTimestamp metav1.Time `json:"firstTimestamp,omitempty" protobuf:"bytes,6,opt,name=firstTimestamp"`
+
+	// The time at which the most recent occurrence of this event was recorded.
+	// +optional
+	LastTimestamp metav1.Time `json:"lastTimestamp,omitempty" protobuf:"bytes,7,opt,name=lastTimestamp"`
+
+	// The number of times this event has occurred.
+	// +optional
+	Count int32 `json:"count,omitempty" protobuf:"varint,8,opt,name=count"`
+
+	// Type of this event (Normal, Warning), new types could be added in the future
+	// +optional
+	Type string `json:"type,omitempty" protobuf:"bytes,9,opt,name=type"`
+
+	// Time when this Event was first observed.
+	// +optional
+	EventTime metav1.MicroTime `json:"eventTime,omitempty" protobuf:"bytes,10,opt,name=eventTime"`
+
+	// Data about the Event series this event represents or nil if it's a singleton Event.
+	// +optional
+	Series *EventSeries `json:"series,omitempty" protobuf:"bytes,11,opt,name=series"`
+
+	// What action was taken/failed regarding to the Regarding object.
+	// +optional
+	Action string `json:"action,omitempty" protobuf:"bytes,12,opt,name=action"`
+
+	// Optional secondary object for more complex actions.
+	// +optional
+	Related *ObjectReference `json:"related,omitempty" protobuf:"bytes,13,opt,name=related"`
+
+	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
+	// +optional
+	ReportingController string `json:"reportingComponent" protobuf:"bytes,14,opt,name=reportingComponent"`
+
+	// ID of the controller instance, e.g. `kubelet-xyzf`.
+	// +optional
+	ReportingInstance string `json:"reportingInstance" protobuf:"bytes,15,opt,name=reportingInstance"`
+}
+```
+If you want to change the body struct with custom struct. You need to use `custom_body_configmap` and `custom_body_configmap_namespace`.    
+The configMap must have a field called `content` and then put custom body template as value of `content`. For example.
+
+```$xslt
+apiVersion: v1
+data:
+  content: >-
+    {"EventType": "{{ .Type }}","EventKind": "{{ .Kind }}""EventReason": "{{
+    .Reason }}","EventTime": "{{ .EventTime }}","EventMessage": "{{ .Message
+    }}"}
+kind: ConfigMap
+metadata: 
+  name: custom-webhook-body 
+  namespace: kube-system 
+```

--- a/sinks/factory.go
+++ b/sinks/factory.go
@@ -27,8 +27,8 @@ import (
 	"github.com/AliyunContainerService/kube-eventer/sinks/mysql"
 	"github.com/AliyunContainerService/kube-eventer/sinks/riemann"
 	"github.com/AliyunContainerService/kube-eventer/sinks/sls"
-	"github.com/AliyunContainerService/kube-eventer/sinks/wechat"
 	"github.com/AliyunContainerService/kube-eventer/sinks/webhook"
+	"github.com/AliyunContainerService/kube-eventer/sinks/wechat"
 	"k8s.io/klog"
 )
 
@@ -57,8 +57,8 @@ func (this *SinkFactory) Build(uri flags.Uri) (core.EventSink, error) {
 		return sls.NewSLSSink(&uri.Val)
 	case "wechat":
 		return wechat.NewWechatSink(&uri.Val)
-	case "wehook":
-		return webhook.NewWebhookSink(&uri.Val)
+	case "webhook":
+		return webhook.NewWebHookSink(&uri.Val)
 	default:
 		return nil, fmt.Errorf("Sink not recognized: %s", uri.Key)
 	}

--- a/sinks/webhook/webhook_test.go
+++ b/sinks/webhook/webhook_test.go
@@ -1,0 +1,41 @@
+package webhook
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/url"
+	"testing"
+)
+
+const (
+	webhookSinkValid = "https://oapi.dingtalk.com/robot/send?access_token=token&level=Normal&namespaces=a,b&kinds=c,d&header=contentType=demo&header=content2=3"
+)
+
+var (
+	kubeSystemNamespaceEventPod = &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "Event2",
+			Namespace: "kube-system",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Pod",
+		},
+		Reason:  "FailedStartUp",
+		Type:    Normal,
+		Message: "DEMO",
+	}
+)
+
+func TestNewWebhookSink(t *testing.T) {
+	uri, err := url.Parse(webhookSinkValid)
+	if err != nil {
+		t.Fatalf("Failed to prase webhookSinkValid,err: %v", err)
+	}
+	w, err := NewWebHookSink(uri)
+	if err != nil {
+		t.Fatalf("Failed to create NewWebhookSink,err: %v", err)
+	}
+
+	assert.True(t, webhookSinkValid == w.endpoint, "endpoint should be the same")
+}

--- a/sources/kubernetes/kubernetes_source.go
+++ b/sources/kubernetes/kubernetes_source.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/AliyunContainerService/kube-eventer/common/kubernetes"
 	"github.com/AliyunContainerService/kube-eventer/core"
 	kubeapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubewatch "k8s.io/apimachinery/pkg/watch"
-	"github.com/AliyunContainerService/kube-eventer/common/kubernetes"
 
 	kubev1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog"


### PR DESCRIPTION
**What type of PR is this?**
**PR类型是什么？**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind feature



**What this PR does / why we need it**:
**这个PR解决了什么问题**:

add generic webhook 

**Which issue(s) this PR fixes**:
**PR相关联issue**:

Fixes #86 


**Does this PR introduce a breaking change?**:
**PR带来的破坏性变更**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 
如果没有，就写 NONE。引入新的外部依赖，更新已有依赖都视为"破坏性变更"
-->
none 

<hr/>
** Docs ** 
### webhook sink

*This sink supports generic webhook and you can use this sink integrated with chatbot(DingTalk,Slack,BearChat and so on) and webhook services.
To use the webhook sink add the following flag:

	--sink=webhook:<WEBHOOK_URL>&level=<Normal or Warning, Warning default>

The following options are available:
* `level` - Level of event (optional. default: Warning. Options: Warning and Normal)
* `namespaces` - Namespaces to filter (optional. default: all namespaces,use commas to separate multi namespaces, Regexp pattern support)
* `kinds` - Kinds to filter (optional. default: all kinds,use commas to separate multi kinds. Options: Node,Pod and so on.)
* `reason` - Reason to filter (optional. default: empty, Regexp pattern support). You can use multi reason field in query.
* `method` - Method to send request (optional. default: GET)
* `header` - Header in request (optional. default: empty). You can use multi header field in query.
* `custom_body_configmap` - The configmap name of request body template. You can use Template to customize request body. (optional.)
* `custom_body_configmap_namespace` -  The configmap namespace of request body template. (optional.)

For example:

   	--sink=webhook:https://oapi.dingtalk.com/robot/send?access_token=a5c19f3e02feba7bd5dfc22bfb04afa212359acfe86fd80eb159187097b7d014&level=Normal&namespaces=a,b&kinds=c,d&header=contentType=customContentType&header=customHeaderKey=customHeaderValue 

#### custom_body_configmap pattern 
The default request body template is below.        
{
	"EventType": "{{ .Type }}",
	"EventKind": "{{ .Kind }}"
	"EventReason": "{{ .Reason }}",
	"EventTime": "{{ .EventTime }}",
	"EventMessage": "{{ .Message }}"
}
```
`kube-eventer` will render template with event to sink. The event struct is below.   
```$xslt
type Event struct {
	metav1.TypeMeta `json:",inline"`
	// Standard object's metadata.
	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
	metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`

	// The object that this event is about.
	InvolvedObject ObjectReference `json:"involvedObject" protobuf:"bytes,2,opt,name=involvedObject"`

	// This should be a short, machine understandable string that gives the reason
	// for the transition into the object's current status.
	// TODO: provide exact specification for format.
	// +optional
	Reason string `json:"reason,omitempty" protobuf:"bytes,3,opt,name=reason"`

	// A human-readable description of the status of this operation.
	// TODO: decide on maximum length.
	// +optional
	Message string `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`

	// The component reporting this event. Should be a short machine understandable string.
	// +optional
	Source EventSource `json:"source,omitempty" protobuf:"bytes,5,opt,name=source"`

	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
	// +optional
	FirstTimestamp metav1.Time `json:"firstTimestamp,omitempty" protobuf:"bytes,6,opt,name=firstTimestamp"`

	// The time at which the most recent occurrence of this event was recorded.
	// +optional
	LastTimestamp metav1.Time `json:"lastTimestamp,omitempty" protobuf:"bytes,7,opt,name=lastTimestamp"`

	// The number of times this event has occurred.
	// +optional
	Count int32 `json:"count,omitempty" protobuf:"varint,8,opt,name=count"`

	// Type of this event (Normal, Warning), new types could be added in the future
	// +optional
	Type string `json:"type,omitempty" protobuf:"bytes,9,opt,name=type"`

	// Time when this Event was first observed.
	// +optional
	EventTime metav1.MicroTime `json:"eventTime,omitempty" protobuf:"bytes,10,opt,name=eventTime"`

	// Data about the Event series this event represents or nil if it's a singleton Event.
	// +optional
	Series *EventSeries `json:"series,omitempty" protobuf:"bytes,11,opt,name=series"`

	// What action was taken/failed regarding to the Regarding object.
	// +optional
	Action string `json:"action,omitempty" protobuf:"bytes,12,opt,name=action"`

	// Optional secondary object for more complex actions.
	// +optional
	Related *ObjectReference `json:"related,omitempty" protobuf:"bytes,13,opt,name=related"`

	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
	// +optional
	ReportingController string `json:"reportingComponent" protobuf:"bytes,14,opt,name=reportingComponent"`

	// ID of the controller instance, e.g. `kubelet-xyzf`.
	// +optional
	ReportingInstance string `json:"reportingInstance" protobuf:"bytes,15,opt,name=reportingInstance"`
}
```
If you want to change the body struct with custom struct. You need to use `custom_body_configmap` and `custom_body_configmap_namespace`.    
The configMap must have a field called `content` and then put custom body template as value of `content`. For example.

```$xslt
apiVersion: v1
data:
  content: >-
    {"EventType": "{{ .Type }}","EventKind": "{{ .Kind }}""EventReason": "{{
    .Reason }}","EventTime": "{{ .EventTime }}","EventMessage": "{{ .Message
    }}"}
kind: ConfigMap
metadata: 
  name: custom-webhook-body 
  namespace: kube-system 
```
<hr/> 

**Test/Final result**:
**测试/最终运行结果**:

```
?   	github.com/AliyunContainerService/kube-eventer	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/api	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/common/elasticsearch	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/common/filters	0.021s
ok  	github.com/AliyunContainerService/kube-eventer/common/flags	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/common/honeycomb	(cached)
?   	github.com/AliyunContainerService/kube-eventer/common/influxdb	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/kafka	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/kubernetes	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/common/librato	(cached)
?   	github.com/AliyunContainerService/kube-eventer/common/mysql	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/riemann	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/core	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/manager	(cached)
?   	github.com/AliyunContainerService/kube-eventer/metrics/core	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks	15.051s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/dingtalk	0.019s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/elasticsearch	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/honeycomb	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/influxdb	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/kafka	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/log	(cached)
?   	github.com/AliyunContainerService/kube-eventer/sinks/mysql	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks/riemann	(cached)
?   	github.com/AliyunContainerService/kube-eventer/sinks/sls	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks/webhook	0.023s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/wechat	(cached)
?   	github.com/AliyunContainerService/kube-eventer/sources	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/sources/kubernetes	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/util	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/version	[no test files]
```

