### PR TITLE
fix: 🐛 webhook sinks filter not work

### DIFF
--- a/sinks/webhook/webhook.go
+++ b/sinks/webhook/webhook.go
@@ -3,17 +3,18 @@ package webhook
 import (
 	"bytes"
 	"fmt"
-	"github.com/AliyunContainerService/kube-eventer/common/filters"
-	"github.com/AliyunContainerService/kube-eventer/common/kubernetes"
-	"github.com/AliyunContainerService/kube-eventer/core"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
 	"net/http"
 	"net/url"
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/AliyunContainerService/kube-eventer/common/filters"
+	"github.com/AliyunContainerService/kube-eventer/common/kubernetes"
+	"github.com/AliyunContainerService/kube-eventer/core"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 const (
@@ -60,6 +61,12 @@ func (ws *WebHookSink) ExportEvents(batch *core.EventBatch) {
 
 // send msg to generic webHook
 func (ws *WebHookSink) Send(event *v1.Event) (err error) {
+
+	for _, v := range ws.filters {
+		if !v.Filter(event) {
+			return
+		}
+	}
 
 	body, err := ws.RenderBodyTemplate(event)
 	if err != nil {

--- a/sinks/webhook/webhook_test.go
+++ b/sinks/webhook/webhook_test.go
@@ -1,15 +1,17 @@
 package webhook
 
 import (
-	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	webhookSinkValid = "https://oapi.dingtalk.com/robot/send?access_token=token&level=Normal&namespaces=a,b&kinds=c,d&header=contentType=demo&header=content2=3"
+	webhookSinkValid  = "https://oapi.dingtalk.com/robot/send?access_token=token&level=Normal&namespaces=a,b&kinds=c,d&header=contentType=demo&header=content2=3"
+	webhookSinkFilter = "https://oapi.example.com/robot/send?access_token=token&level=Normal&namespaces=a,b&kinds=c,d&reason=Failed&header=contentType=demo&header=content2=3"
 )
 
 var (
@@ -20,6 +22,19 @@ var (
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Pod",
+		},
+		Reason:  "FailedStartUp",
+		Type:    Normal,
+		Message: "DEMO",
+	}
+
+	newWebhookFilterEventPod = &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "Event1",
+			Namespace: "a",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "c",
 		},
 		Reason:  "FailedStartUp",
 		Type:    Normal,
@@ -38,4 +53,30 @@ func TestNewWebhookSink(t *testing.T) {
 	}
 
 	assert.True(t, webhookSinkValid == w.endpoint, "endpoint should be the same")
+}
+
+func TestNewWebhookFilter(t *testing.T) {
+	uri, err := url.Parse(webhookSinkFilter)
+	if err != nil {
+		t.Fatalf("Failed to prase webhookSinkFilter,err: %v", err)
+	}
+	w, err := NewWebHookSink(uri)
+	if err != nil {
+		t.Fatalf("Failed to create NewWebhookSink,err: %v", err)
+	}
+
+	assert.True(t, webhookSinkFilter == w.endpoint, "endpoint should be the same")
+	assert.True(t, w.MockSend(newWebhookFilterEventPod), "newWebhookFilterEventPod should be matched.")
+	assert.False(t, w.MockSend(kubeSystemNamespaceEventPod), "kubeSystemNamespaceEventPod should not be matched.")
+}
+
+func (ws *WebHookSink) MockSend(event *v1.Event) (matched bool) {
+	for _, v := range ws.filters {
+		if !v.Filter(event) {
+			// this event should not be send
+			return false
+		}
+	}
+	// this event should be send, this return value just for testing
+	return true
 }


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  Here are some tips for you: 
感谢你提交了 pull request ，一些 tips 供您参考：

-->

**What type of PR is this?**
**PR类型是什么？**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>bug


**What this PR does / why we need it**:
**这个PR解决了什么问题**:
webhook sink filter not work

**Which issue(s) this PR fixes**:
**PR相关联issue**:
https://github.com/AliyunContainerService/kube-eventer/issues/101

Fixes #


**Does this PR introduce a breaking change?**:
**PR带来的破坏性变更**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 
如果没有，就写 NONE。引入新的外部依赖，更新已有依赖都视为"破坏性变更"
-->
None
```docs

```

**Test/Final result**:
**测试/最终运行结果**:
<!--
You can put some pictures or show your test result.
放几张图片或测试结果
-->
![image](https://user-images.githubusercontent.com/17743739/82296757-40fae880-99e4-11ea-8cb7-043ca6d33102.png)


