### PR TITLE
fix http client error and sls fmt check

### DIFF
--- a/sinks/dingtalk/dingtalk.go
+++ b/sinks/dingtalk/dingtalk.go
@@ -157,11 +157,11 @@ func (d *DingTalkSink) Ding(event *v1.Event) {
 	b := bytes.NewBuffer(msg_bytes)
 
 	resp, err := http.Post(fmt.Sprintf("https://%s?access_token=%s", d.Endpoint, d.Token), CONTENT_TYPE_JSON, b)
-	defer resp.Body.Close()
 	if err != nil {
 		klog.Errorf("failed to send msg to dingtalk. error: %s", err.Error())
 		return
 	}
+	defer resp.Body.Close()
 	if resp != nil && resp.StatusCode != http.StatusOK {
 		klog.Errorf("failed to send msg to dingtalk, because the response code is %d", resp.StatusCode)
 		return

--- a/sinks/sls/sls.go
+++ b/sinks/sls/sls.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/url"
@@ -108,7 +107,7 @@ func (s *SLSSink) ExportEvents(batch *core.EventBatch) {
 
 	err := s.client().PutLogs(request)
 	if err != nil {
-		klog.Errorf("failed to put events to sls,because of %s", err.Error())
+		klog.Errorf("failed to put events to sls,because of %v", err)
 	}
 }
 
@@ -238,7 +237,7 @@ func newClient(c *Config) (*sls.Client, error) {
 	if err != nil {
 		region, err = m.Region()
 		if err != nil {
-			klog.Errorf("failed to get Region,because of %s", err.Error())
+			klog.Errorf("failed to get Region,because of %v", err)
 			return nil, err
 		}
 	}
@@ -272,10 +271,10 @@ func newClient(c *Config) (*sls.Client, error) {
 		layout := "2006-01-02T15:04:05Z"
 		t, err := time.Parse(layout, akInfo.Expiration)
 		if err != nil {
-			fmt.Errorf(err.Error())
+			klog.Errorf("failed to parse time layout, %v", err)
 		}
 		if t.Before(time.Now()) {
-			klog.Errorf("invalid token which is expired")
+			klog.Error("invalid token which is expired")
 		}
 		klog.Info("get token by ram role.")
 		akInfo.AccessKeyId = string(ak)
@@ -284,13 +283,13 @@ func newClient(c *Config) (*sls.Client, error) {
 	} else {
 		roleName, err := m.RoleName()
 		if err != nil {
-			klog.Errorf("failed to get RoleName,because of %s", err.Error())
+			klog.Errorf("failed to get RoleName,because of %v", err)
 			return nil, err
 		}
 
 		auth, err := m.RamRoleToken(roleName)
 		if err != nil {
-			klog.Errorf("failed to get RamRoleToken,because of %s", err.Error())
+			klog.Errorf("failed to get RamRoleToken,because of %v", err)
 			return nil, err
 		}
 		akInfo.AccessKeyId = auth.AccessKeyId


### PR DESCRIPTION
**What type of PR is this?**
**PR类型是什么？**

> /kind bug

**What this PR does / why we need it**:
**这个PR解决了什么问题**:

* Fix panic when http client defer close 
* Fix sls sink go fmt 

**Which issue(s) this PR fixes**:
**PR相关联issue**:

Fixes #114 


**Does this PR introduce a breaking change?**:
**PR带来的破坏性变更**:
No 



**Test/Final result**:
**测试/最终运行结果**:
<!--
You can put some pictures or show your test result.
放几张图片或测试结果
-->
```
?   	github.com/AliyunContainerService/kube-eventer	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/api	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/common/elasticsearch	0.027s
ok  	github.com/AliyunContainerService/kube-eventer/common/filters	0.059s
ok  	github.com/AliyunContainerService/kube-eventer/common/flags	0.040s
ok  	github.com/AliyunContainerService/kube-eventer/common/honeycomb	0.018s
?   	github.com/AliyunContainerService/kube-eventer/common/influxdb	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/kafka	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/kubernetes	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/common/librato	0.017s
?   	github.com/AliyunContainerService/kube-eventer/common/mysql	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/riemann	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/core	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/manager	4.529s
?   	github.com/AliyunContainerService/kube-eventer/metrics/core	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks	93.047s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/dingtalk	0.050s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/elasticsearch	0.023s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/honeycomb	0.018s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/influxdb	0.026s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/kafka	0.017s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/log	0.020s
?   	github.com/AliyunContainerService/kube-eventer/sinks/mysql	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks/riemann	0.016s
?   	github.com/AliyunContainerService/kube-eventer/sinks/sls	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks/webhook	0.022s
ok  	github.com/AliyunContainerService/kube-eventer/sinks/wechat	0.016s
?   	github.com/AliyunContainerService/kube-eventer/sources	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/sources/kubernetes	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/util	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/version	[no test files]
```
