### PR TITLE
ready to release v1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
 ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 
 
-VERSION?=v1.1.0
+VERSION?=v1.2.0
 GIT_COMMIT:=$(shell git rev-parse --short HEAD)
 
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccount: kube-eventer
       containers:
-        - image: registry.aliyuncs.com/acs/kube-eventer-amd64:v1.1.0-252b712-aliyun
+        - image: registry.aliyuncs.com/acs/kube-eventer-amd64:v1.2.0-ed61f19-aliyun
           name: kube-eventer
           command:
             - "/kube-eventer"

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -20,7 +20,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccount: kube-eventer
       containers:
-        - image: registry.aliyuncs.com/acs/kube-eventer-amd64:v1.1.0-252b712-aliyun
+        - image: registry.aliyuncs.com/acs/kube-eventer-amd64:v1.2.0-ed61f19-aliyun
           name: kube-eventer
           command:
             - "/kube-eventer"


### PR DESCRIPTION
**What type of PR is this?**
**PR类型是什么？**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind release 


**What this PR does / why we need it**:
**这个PR解决了什么问题**:

Release v1.2.0



**Does this PR introduce a breaking change?**:
**PR带来的破坏性变更**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 
如果没有，就写 NONE。引入新的外部依赖，更新已有依赖都视为"破坏性变更"
-->

None 

**Test/Final result**:
**测试/最终运行结果**:
<!--
You can put some pictures or show your test result.
放几张图片或测试结果
-->

```
?   	github.com/AliyunContainerService/kube-eventer	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/api	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/common/elasticsearch	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/common/filters	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/common/flags	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/common/honeycomb	(cached)
?   	github.com/AliyunContainerService/kube-eventer/common/influxdb	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/kafka	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/kubernetes	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/common/librato	(cached)
?   	github.com/AliyunContainerService/kube-eventer/common/mysql	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/common/riemann	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/core	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/manager	(cached)
?   	github.com/AliyunContainerService/kube-eventer/metrics/core	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/dingtalk	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/elasticsearch	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/honeycomb	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/influxdb	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/kafka	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/log	(cached)
?   	github.com/AliyunContainerService/kube-eventer/sinks/mysql	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks/riemann	(cached)
?   	github.com/AliyunContainerService/kube-eventer/sinks/sls	[no test files]
ok  	github.com/AliyunContainerService/kube-eventer/sinks/webhook	(cached)
ok  	github.com/AliyunContainerService/kube-eventer/sinks/wechat	(cached)
?   	github.com/AliyunContainerService/kube-eventer/sources	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/sources/kubernetes	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/util	[no test files]
?   	github.com/AliyunContainerService/kube-eventer/version	[no test files]
```

