### PR TITLE
call the Stop method when the outer stopChannel triggered.

### DIFF
--- a/sources/kubernetes/kubernetes_source.go
+++ b/sources/kubernetes/kubernetes_source.go
@@ -165,6 +165,7 @@ func (this *KubernetesEventSource) watch() {
 				}
 
 			case <-this.stopChannel:
+				watcher.Stop()
 				klog.Infof("Event watching stopped")
 				return
 			}


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
we need to call the Stop method of the watchInterface to do the cleanup work when process stopChannel triggered.

**Does this PR introduce a breaking change?**:
NONE

