### PR TITLE
Update webhook-sink.md

### DIFF
--- a/docs/en/webhook-sink.md
+++ b/docs/en/webhook-sink.md
@@ -138,7 +138,7 @@ configmap Body
 #### slack 
 Params 
 ```
---sink=https://hooks.slack.com/services/d/B00000000/XXX?&level=Normal&kinds=Pod&header=Content-Type=application/json&custom_body_configmap=custom-body&custom_body_configmap_namespace=kube-system&method=POST
+--sink=webhook:https://hooks.slack.com/services/d/B00000000/XXX?&level=Normal&kinds=Pod&header=Content-Type=application/json&custom_body_configmap=custom-body&custom_body_configmap_namespace=kube-system&method=POST
 ```
 configmap Body 
 ```


### PR DESCRIPTION
fix slack miss webhook prefix

> /kind documentation


**What this PR does / why we need it**:
**这个PR解决了什么问题**:
fix slack miss webhook prefix


Fixes #
fix slack miss webhook prefix

**Does this PR introduce a breaking change?**:
**PR带来的破坏性变更**:
NONE

```docs

```



