### PR TITLE
fix FailedScheduling event write to sls with wrong timestamp.

### DIFF
--- a/sinks/sls/sls.go
+++ b/sinks/sls/sls.go
@@ -114,7 +114,7 @@ func (s *SLSSink) ExportEvents(batch *core.EventBatch) {
 
 func getEventTime(event *v1.Event) uint32 {
 
-	if !event.LastTimestamp.IsZero(){
+	if !event.LastTimestamp.IsZero() {
 		return uint32(event.LastTimestamp.Unix())
 	}
 

--- a/sinks/sls/sls.go
+++ b/sinks/sls/sls.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"net/url"
 	"os"
@@ -84,7 +85,7 @@ func (s *SLSSink) ExportEvents(batch *core.EventBatch) {
 	for _, event := range batch.Events {
 		log := &sls.Log{}
 
-		time := uint32(event.LastTimestamp.Unix())
+		time := getEventTime(event)
 
 		log.Time = &time
 
@@ -109,6 +110,19 @@ func (s *SLSSink) ExportEvents(batch *core.EventBatch) {
 	if err != nil {
 		klog.Errorf("failed to put events to sls,because of %v", err)
 	}
+}
+
+func getEventTime(event *v1.Event) uint32 {
+
+	if !event.LastTimestamp.IsZero(){
+		return uint32(event.LastTimestamp.Unix())
+	}
+
+	if !event.EventTime.IsZero() {
+		return uint32(event.EventTime.Unix())
+	}
+
+	return uint32(metav1.Now().Unix())
 }
 
 func (s *SLSSink) Stop() {


### PR DESCRIPTION
**What type of PR is this?**
**PR类型是什么？**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> kind bug


**What this PR does / why we need it**:
**这个PR解决了什么问题**:

The event with reason of 'FailedScheduling', write to sls with wrong timestamp.

**Test/Final result**:
**测试/最终运行结果**:
write 'FailedScheduling' event to sls success. 


