### PR TITLE
Fix honeycomb typo

### DIFF
--- a/docs/en/honeycomb-sink.md
+++ b/docs/en/honeycomb-sink.md
@@ -8,7 +8,7 @@ Options can be set in query string, like this:
 
 * `dataset` - Honeycomb Dataset to which to publish metrics/events
 * `writekey` - Honeycomb Write Key for your account
-* `apihost` - Option to send metrics to a different host (default: https://api.honeycomb.com) (optional)
+* `apihost` - Option to send metrics to a different host (default: https://api.honeycomb.io) (optional)
 
 For example,
 


### PR DESCRIPTION
`.com` is not the default

https://github.com/AliyunContainerService/kube-eventer/blob/master/common/honeycomb/honeycomb.go#L43


<!--  
Thanks for sending a pull request!  Here are some tips for you: 
感谢你提交了 pull request ，一些 tips 供您参考：

-->

/kind documentation


**What this PR does / why we need it**: Fixes a typo in docs
**这个PR解决了什么问题**:

**Does this PR introduce a breaking change?**:
**PR带来的破坏性变更**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 
如果没有，就写 NONE。引入新的外部依赖，更新已有依赖都视为"破坏性变更"
-->

```docs
NONE
```


