### PR TITLE
fixbug: Webhook which is setted Normal Level cannot sink Warning Events

### DIFF
--- a/sinks/webhook/webhook.go
+++ b/sinks/webhook/webhook.go
@@ -128,6 +128,16 @@ func (ws *WebHookSink) Stop() {
 	return
 }
 
+func getLevels(level string) []string {
+	switch level {
+	case Normal:
+		return []string{Normal, Warning}
+	case Warning:
+		return []string{Warning}
+	}
+	return []string{Warning}
+}
+
 // init WebHookSink with url params
 func NewWebHookSink(uri *url.URL) (*WebHookSink, error) {
 	s := &WebHookSink{
@@ -156,7 +166,7 @@ func NewWebHookSink(uri *url.URL) (*WebHookSink, error) {
 	level := Warning
 	if len(opts["level"]) >= 1 {
 		level = opts["level"][0]
-		s.filters["LevelFilter"] = filters.NewGenericFilter("Type", []string{level}, false)
+		s.filters["LevelFilter"] = filters.NewGenericFilter("Type", getLevels(level), false)
 	}
 
 	if len(opts["namespaces"]) >= 1 {


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  Here are some tips for you: 
感谢你提交了 pull request ，一些 tips 供您参考：

-->

**What type of PR is this?**
**PR类型是什么？**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

bug


**What this PR does / why we need it**:
**这个PR解决了什么问题**:
sink的Webhook的Level为Nomal时，并不能推送Warning Level的Event。

**Which issue(s) this PR fixes**:
**PR相关联issue**:

Fixes #214


**Does this PR introduce a breaking change?**:
**PR带来的破坏性变更**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 
如果没有，就写 NONE。引入新的外部依赖，更新已有依赖都视为"破坏性变更"
-->

```docs
NONE
```

**Test/Final result**:
**测试/最终运行结果**:
<!--
You can put some pictures or show your test result.
放几张图片或测试结果
-->
Build 成功
![image](https://user-images.githubusercontent.com/37376634/164965993-27ce1700-372d-4169-ab39-28351fd65703.png)


