### PR TITLE
修复所有Sink的EventTimestamp逻辑，适配无lastTimestamp情况

### DIFF
--- a/sinks/dingtalk/dingtalk.go
+++ b/sinks/dingtalk/dingtalk.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"net/http"
 	"net/url"
 	"strings"
@@ -38,7 +39,6 @@ const (
 	DEFAULT_MSG_TYPE      = "text"
 	CONTENT_TYPE_JSON     = "application/json"
 	LABEL_TEMPLATE        = "%s\n"
-	TIME_FORMAT           = "2006-01-02 15:04:05"
 )
 
 var (
@@ -55,7 +55,8 @@ var (
 	}
 )
 
-/**
+/*
+*
 dingtalk msg struct
 */
 type DingTalkMsg struct {
@@ -73,7 +74,8 @@ type DingTalkText struct {
 	Content string `json:"content"`
 }
 
-/**
+/*
+*
 dingtalk sink usage
 --sink:dingtalk:https://oapi.dingtalk.com/robot/send?access_token=[access_token]&level=Warning&label=[label]
 
@@ -226,7 +228,7 @@ func createMsgFromEvent(d *DingTalkSink, event *v1.Event) *DingTalkMsg {
 			}
 		}
 		msg.Text = DingTalkText{
-			Content: fmt.Sprintf(template, event.Type, event.InvolvedObject.Kind, event.Namespace, event.Name, event.Reason, event.LastTimestamp.Format(TIME_FORMAT), event.Message),
+			Content: fmt.Sprintf(template, event.Type, event.InvolvedObject.Kind, event.Namespace, event.Name, event.Reason, util.GetLastEventTimestamp(event).Format(time.DateTime), event.Message),
 		}
 		break
 	}

--- a/sinks/dingtalk/markdownMsgBuilder.go
+++ b/sinks/dingtalk/markdownMsgBuilder.go
@@ -2,6 +2,7 @@ package dingtalk
 
 import (
 	"fmt"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -80,7 +81,7 @@ func NewMarkdownMsgBuilder(clusterID, region string, event *v1.Event) *MarkdownM
 		break
 	}
 	reason := fmt.Sprintf(MARKDOWN_TEXT_BOLD, event.Reason)
-	timestamp := fmt.Sprintf(MARKDOWN_TEXT_BOLD, event.LastTimestamp.String())
+	timestamp := fmt.Sprintf(MARKDOWN_TEXT_BOLD, util.GetLastEventTimestamp(event).String())
 	message := fmt.Sprintf(MARKDOWN_TEXT_BOLD, event.Message)
 	m.OutputText = fmt.Sprintf(MARKDOWN_TEMPLATE, level, kind, namespace, name, reason, timestamp, message)
 	return &m

--- a/sinks/elasticsearch/driver.go
+++ b/sinks/elasticsearch/driver.go
@@ -15,6 +15,7 @@
 package elasticsearch
 
 import (
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"net/url"
 	"sync"
 	"time"
@@ -57,17 +58,17 @@ type EsSinkPoint struct {
 
 func eventToPoint(event *kube_api.Event, clusterName string) (*EsSinkPoint, error) {
 	var (
-		lastOccurrenceTimestamp  = event.LastTimestamp.Time.UTC()
 		firstOccurrenceTimestamp = event.FirstTimestamp.Time.UTC()
+		lastOccurrenceTimestamp  = util.GetLastEventTimestamp(event).UTC()
 	)
 
 	// Part of k8s resources FirstOccurrenceTimestamp/LastOccurrenceTimestamp is nil
-	if event.LastTimestamp.UTC().IsZero() {
-		lastOccurrenceTimestamp = event.CreationTimestamp.Time.UTC()
+	if util.GetLastEventTimestamp(event).UTC().IsZero() {
+		lastOccurrenceTimestamp = util.GetLastEventTimestamp(event).UTC()
 	}
 
-	if event.FirstTimestamp.UTC().IsZero() {
-		firstOccurrenceTimestamp = event.CreationTimestamp.Time.UTC()
+	if event.FirstTimestamp.Time.UTC().IsZero() {
+		firstOccurrenceTimestamp = event.FirstTimestamp.Time.UTC()
 	}
 
 	point := EsSinkPoint{

--- a/sinks/eventbridge/driver.go
+++ b/sinks/eventbridge/driver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/AliyunContainerService/kube-eventer/core"
 	"github.com/AliyunContainerService/kube-eventer/sinks/utils"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"github.com/alibabacloud-go/eventbridge-sdk/eventbridge"
 	ebUtil "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/google/uuid"
@@ -141,7 +142,7 @@ func (ebSink *eventBridgeSink) toCloudEvent(event *v1.Event) (*eventbridge.Cloud
 		SetData(dataBytes).
 		SetId(uuid.New().String()).
 		SetSource(aliyunContainerServiceSource).
-		SetTime(time.Now().UTC().Format(time.RFC3339)).
+		SetTime(util.GetLastEventTimestamp(event).UTC().Format(time.RFC3339)).
 		SetSubject(subject).
 		SetType(eType).
 		SetExtensions(map[string]interface{}{

--- a/sinks/honeycomb/driver.go
+++ b/sinks/honeycomb/driver.go
@@ -15,6 +15,7 @@
 package honeycomb
 
 import (
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"net/url"
 	"sync"
 
@@ -66,7 +67,7 @@ func (sink *honeycombSink) ExportEvents(eventBatch *event_core.EventBatch) {
 		data := getExportedData(event)
 		exportedBatch[i] = &honeycomb_common.BatchPoint{
 			Data:      data,
-			Timestamp: event.LastTimestamp.UTC(),
+			Timestamp: util.GetLastEventTimestamp(event).UTC(),
 		}
 	}
 	err := sink.client.SendBatch(exportedBatch)

--- a/sinks/influxdb/influxdb.go
+++ b/sinks/influxdb/influxdb.go
@@ -17,6 +17,7 @@ package influxdb
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"net/url"
 	"strings"
 	"sync"
@@ -69,7 +70,7 @@ func getEventValue(event *kube_api.Event) (string, error) {
 func eventToPointWithFields(event *kube_api.Event) (*influxdb.Point, error) {
 	point := influxdb.Point{
 		Measurement: "events",
-		Time:        event.LastTimestamp.Time.UTC(),
+		Time:        util.GetLastEventTimestamp(event).UTC(),
 		Fields: map[string]interface{}{
 			"message": event.Message,
 		},
@@ -98,7 +99,7 @@ func eventToPoint(event *kube_api.Event) (*influxdb.Point, error) {
 
 	point := influxdb.Point{
 		Measurement: eventMeasurementName,
-		Time:        event.LastTimestamp.Time.UTC(),
+		Time:        util.GetLastEventTimestamp(event).UTC(),
 		Fields: map[string]interface{}{
 			valueField: value,
 		},

--- a/sinks/kafka/driver.go
+++ b/sinks/kafka/driver.go
@@ -16,6 +16,7 @@ package kafka
 
 import (
 	"encoding/json"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"net/url"
 	"sync"
 	"time"
@@ -54,7 +55,7 @@ func eventToPoint(event *kube_api.Event) (*KafkaSinkPoint, error) {
 		return nil, err
 	}
 	point := KafkaSinkPoint{
-		EventTimestamp: event.LastTimestamp.Time.UTC(),
+		EventTimestamp: util.GetLastEventTimestamp(event).UTC(),
 		EventValue:     value,
 		EventTags: map[string]string{
 			"eventID": string(event.UID),

--- a/sinks/log/log_sink.go
+++ b/sinks/log/log_sink.go
@@ -17,6 +17,7 @@ package logsink
 import (
 	"bytes"
 	"fmt"
+	"github.com/AliyunContainerService/kube-eventer/util"
 
 	"github.com/AliyunContainerService/kube-eventer/core"
 	"k8s.io/klog"
@@ -37,7 +38,7 @@ func batchToString(batch *core.EventBatch) string {
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf("EventBatch     Timestamp: %s\n", batch.Timestamp))
 	for _, event := range batch.Events {
-		buffer.WriteString(fmt.Sprintf("%++v   %s (cnt:%d): %s\n", event, event.LastTimestamp, event.Count, event.Message))
+		buffer.WriteString(fmt.Sprintf("%++v   %s (cnt:%d): %s\n", event, util.GetLastEventTimestamp(event), event.Count, event.Message))
 	}
 	return buffer.String()
 }

--- a/sinks/mongo/mongo.go
+++ b/sinks/mongo/mongo.go
@@ -17,6 +17,7 @@ package mongo
 import (
 	"context"
 	"github.com/AliyunContainerService/kube-eventer/core"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	kube_api "k8s.io/api/core/v1"
@@ -62,17 +63,17 @@ func (m *mongoSink) saveData(sinkData *mongoSinkPoint) error {
 
 func eventToPoint(event *kube_api.Event) (*mongoSinkPoint, error) {
 	var (
-		lastOccurrenceTimestamp  = event.LastTimestamp.Time.UTC()
 		firstOccurrenceTimestamp = event.FirstTimestamp.Time.UTC()
+		lastOccurrenceTimestamp  = util.GetLastEventTimestamp(event).UTC()
 	)
 
 	// Part of k8s resources FirstOccurrenceTimestamp/LastOccurrenceTimestamp is nil
-	if event.LastTimestamp.UTC().IsZero() {
-		lastOccurrenceTimestamp = event.CreationTimestamp.Time.UTC()
+	if util.GetLastEventTimestamp(event).UTC().IsZero() {
+		lastOccurrenceTimestamp = util.GetLastEventTimestamp(event).UTC()
 	}
 
 	if event.FirstTimestamp.UTC().IsZero() {
-		firstOccurrenceTimestamp = event.CreationTimestamp.Time.UTC()
+		firstOccurrenceTimestamp = event.FirstTimestamp.Time.UTC()
 	}
 
 	point := mongoSinkPoint{

--- a/sinks/mysql/mysql.go
+++ b/sinks/mysql/mysql.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	mysql_common "github.com/AliyunContainerService/kube-eventer/common/mysql"
 	"github.com/AliyunContainerService/kube-eventer/core"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	kube_api "k8s.io/api/core/v1"
 	"k8s.io/klog"
 	"net/url"
@@ -81,7 +82,7 @@ func eventToPoint(event *kube_api.Event) (*mysql_common.MysqlKubeEventPoint, err
 		Message:                  event.Message,
 		Kind:                     event.InvolvedObject.Kind,
 		FirstOccurrenceTimestamp: event.FirstTimestamp.Time.String(),
-		LastOccurrenceTimestamp:  event.LastTimestamp.Time.String(),
+		LastOccurrenceTimestamp:  util.GetLastEventTimestamp(event).String(),
 	}
 
 	return &point, nil

--- a/sinks/riemann/driver.go
+++ b/sinks/riemann/driver.go
@@ -15,6 +15,7 @@
 package riemann
 
 import (
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"net/url"
 	"strconv"
 	"strings"
@@ -75,8 +76,8 @@ func appendEvent(events []riemanngo.Event, sink *RiemannSink, event *kube_api.Ev
 	if !event.FirstTimestamp.IsZero() {
 		firstTimestamp = strconv.FormatInt(event.FirstTimestamp.Unix(), 10)
 	}
-	if !event.LastTimestamp.IsZero() {
-		lastTimestamp = strconv.FormatInt(event.LastTimestamp.Unix(), 10)
+	if !util.GetLastEventTimestamp(event).IsZero() {
+		lastTimestamp = strconv.FormatInt(util.GetLastEventTimestamp(event).Unix(), 10)
 	}
 	riemannEvent := riemanngo.Event{
 		Time:        timestamp,

--- a/sinks/sls/sls.go
+++ b/sinks/sls/sls.go
@@ -19,10 +19,10 @@ import (
 	"github.com/AliyunContainerService/kube-eventer/core"
 	metrics_core "github.com/AliyunContainerService/kube-eventer/metrics/core"
 	"github.com/AliyunContainerService/kube-eventer/sinks/utils"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/sls"
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 	"log"
 	"net/url"
@@ -72,7 +72,7 @@ func (s *SLSSink) ExportEvents(batch *core.EventBatch) {
 	for _, event := range batch.Events {
 		log := &sls.Log{}
 
-		time := getEventTime(event)
+		time := uint32(util.GetLastEventTimestamp(event).Unix())
 
 		log.Time = &time
 
@@ -97,19 +97,6 @@ func (s *SLSSink) ExportEvents(batch *core.EventBatch) {
 	if err != nil {
 		klog.Errorf("failed to put events to sls,because of %v", err)
 	}
-}
-
-func getEventTime(event *v1.Event) uint32 {
-
-	if !event.LastTimestamp.IsZero() {
-		return uint32(event.LastTimestamp.Unix())
-	}
-
-	if !event.EventTime.IsZero() {
-		return uint32(event.EventTime.Unix())
-	}
-
-	return uint32(metav1.Now().Unix())
 }
 
 func (s *SLSSink) Stop() {

--- a/sinks/webhook/webhook.go
+++ b/sinks/webhook/webhook.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"bytes"
 	"fmt"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -116,6 +117,7 @@ func (ws *WebHookSink) RenderBodyTemplate(event *v1.Event) (body string, err err
 		return "", err
 	}
 	event.Message = strings.Replace(event.Message, `"`, ``, -1)
+	event.LastTimestamp = metav1.Time{Time: util.GetLastEventTimestamp(event)}
 	if err := tp.Execute(&tpl, event); err != nil {
 		klog.Errorf("Failed to renderTemplate,because of %v", err)
 		return "", err

--- a/sinks/wechat/wechat.go
+++ b/sinks/wechat/wechat.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/AliyunContainerService/kube-eventer/util"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -227,7 +228,7 @@ func createMsgFromEvent(d *WechatSink, event *v1.Event) *WechatMsg {
 	}
 
 	msg.Text = WechatText{
-		Content: fmt.Sprintf(template, event.Type, event.InvolvedObject.Kind, event.Namespace, event.Name, event.Reason, event.LastTimestamp.String(), event.Message),
+		Content: fmt.Sprintf(template, event.Type, event.InvolvedObject.Kind, event.Namespace, event.Name, event.Reason, util.GetLastEventTimestamp(event).String(), event.Message),
 	}
 
 	return msg

--- a/util/common.go
+++ b/util/common.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"k8s.io/api/core/v1"
+	"time"
+)
+
+func GetLastEventTimestamp(event *v1.Event) time.Time {
+
+	if !event.LastTimestamp.IsZero() {
+		return event.LastTimestamp.Time
+	}
+
+	if !event.EventTime.IsZero() {
+		return event.EventTime.Time
+	}
+
+	return time.Now()
+}


### PR DESCRIPTION
修复，当event没有形成series时，只有eventTimestamp字段，无first、lastTimestamp，会造成如FailedScheduling等单次事件记录时无时间戳情况。	258e6e5	行疾 <shichun.fsc@alibaba-inc.com>	2023年8月28日 下午4:48
