### PR TITLE
fix(webhook): 优化消息内容清理逻辑

### DIFF
--- a/sinks/webhook/webhook_test.go
+++ b/sinks/webhook/webhook_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -79,7 +80,7 @@ func TestRenderMessageWithDoubleQuote(t *testing.T) {
 	}
 	event := &v1.Event{
 		Type:    Warning,
-		Message: "pod \"demo-1rare3\" OOMKilled",
+		Message: "pod \"demo-1rare3\" OOMKilled\n",
 	}
 	w.bodyTemplate = `{"EventMessage": "{{ .Message }}"}`
 	template, _ := w.RenderBodyTemplate(event)
@@ -95,4 +96,10 @@ func (ws *WebHookSink) MockSend(event *v1.Event) (matched bool) {
 	}
 	// this event should be send, this return value just for testing
 	return true
+}
+func TestSanitizeMessage(t *testing.T) {
+	Message := "---pod \"demo-1rare3\" OOMKilled\n---"
+	fmt.Println(Message)
+	sanitizedMessage := sanitizeMessage(Message)
+	fmt.Println(sanitizedMessage)
 }


### PR DESCRIPTION
故障现象
```log
E1112 11:29:00.813104       1 webhook.go:105] failed to send msg to sink, because the response code is 400, body is : 
W1112 11:29:00.813121       1 webhook.go:57] Failed to send event to WebHook sink,because of failed to send msg to sink, because the response code is 400, body is :
```

```log
E1112 16:18:00.884926       1 webhook.go:124] ---Readiness probe failed: calico/node is not ready: BIRD is not ready: Error querying BIRD: unable to connect to BIRDv4 socket: dial unix /var/run/calico/bird.ctl: connect: connection refused
---
E1112 16:18:00.885003       1 webhook.go:80] body 
{
        "EventType": "Warning",
        "EventName": "calico-node-shgbq",
        "EventNamespace": "kube-system",
        "EventKind": "Pod",
        "EventReason": "Unhealthy",
        "EventTime": "2024-11-12 16:17:43 +0800 CST",
        "EventMessage": "Readiness probe failed: calico/node is not ready: BIRD is not ready: Error querying BIRD: unable to connect to BIRDv4 socket: dial unix /var/run/calico/bird.ctl: connect: connection refused
"
}
E1112 16:18:00.885020       1 webhook.go:84] req.Body {
{
        "EventType": "Warning",
        "EventName": "calico-node-shgbq",
        "EventNamespace": "kube-system",
        "EventKind": "Pod",
        "EventReason": "Unhealthy",
        "EventTime": "2024-11-12 16:17:43 +0800 CST",
        "EventMessage": "Readiness probe failed: calico/node is not ready: BIRD is not ready: Error querying BIRD: unable to connect to BIRDv4 socket: dial unix /var/run/calico/bird.ctl: connect: connection refused
"
}}
```
修复代码
sinks/webhook/webhook.go
```go
120 - event.Message = strings.Replace(event.Message, `"`, ``, -1)
120 + event.Message = sanitizeMessage(event.Message)
```
新增函数
```go
// sanitizeMessage 清理消息中的特定字符。
// 该函数主要用于移除消息字符串中的引号、换行符和制表符，以确保消息的格式符合特定要求。
// 参数:
//   message (string): 需要清理的原始消息字符串。
// 返回值:
//   string: 清理后的消息字符串。
func sanitizeMessage(message string) string {
    // 检查消息是否为空，如果为空则直接返回。
    // 这样做可以避免对空字符串进行不必要的处理，提高函数效率。
    if message == "" {
        return message
    }

    // 使用strings.Builder高效地构建字符串。
    // Builder提供了一种灵活且高效的方式来构建字符串，特别适用于需要动态构建字符串的场景。
    var b strings.Builder
    // 遍历消息中的每个字符。
    for _, r := range message {
        // 根据字符的不同，采取不同的处理方式。
        switch r {
        case '"', '\n', '\t':
            // 对于引号、换行符和制表符，跳过这些字符，不将其写入最终的消息中。
            // 这是为了确保消息中不包含可能引起误解或格式问题的特殊字符。
            continue
        default:
            // 对于其他字符，将其添加到Builder中。
            b.WriteRune(r)
        }
    }
    // 返回构建好的字符串。
    return b.String()
}
```
test
sinks/webhook/webhook_test.go
```go
func TestRenderMessageWithDoubleQuote(t *testing.T) {
	uri, err := url.Parse(webhookSink)
	if err != nil {
		t.Fatalf("Failed to prase webhookSinkFilter,err: %v", err)
	}
	w, err := NewWebHookSink(uri)
	if err != nil {
		t.Fatalf("Failed to create NewWebhookSink,err: %v", err)
	}
	event := &v1.Event{
		Type:    Warning,
		Message: "pod \"demo-1rare3\" OOMKilled\n",
	}
	w.bodyTemplate = `{"EventMessage": "{{ .Message }}"}`
	template, _ := w.RenderBodyTemplate(event)
	assert.Equal(t, `{"EventMessage": "pod demo-1rare3 OOMKilled"}`, template)
}
```