### PR TITLE
high availability

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/klog"
+)
+
+const (
+	LeaseLockName      = "eventer-lease-lock"
+	LeaseLockNamespace = "kube-system"
+)
+
+func main() {
+	klog.InitFlags(nil)
+	defer klog.Flush()
+
+	// Leader id, needs to be unique
+	id, err := os.Hostname()
+	if err != nil {
+		klog.Fatal(err)
+	}
+	id = id + "_" + string(uuid.NewUUID())
+	klog.Infof("current replica id is %s\n", id)
+
+	var startedLeading atomic.Bool
+
+	// leader election uses the Kubernetes API by writing to a
+	// lock object, which can be a LeaseLock object (preferred),
+	// a ConfigMap, or an Endpoints (deprecated) object.
+	// Conflicting writes are detected and each client handles those actions
+	// independently.
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		klog.Fatal(err)
+	}
+	client := clientset.NewForConfigOrDie(config)
+
+	end := make(<-chan struct{})
+	run := func(ctx context.Context) {
+		// complete your controller loop here
+		klog.Info("kube-eventer start...")
+		end = eventer(ctx)
+	}
+
+	// use a Go context so we can tell the leaderelection code when we
+	// want to step down
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// listen for interrupts or the Linux SIGTERM signal and cancel
+	// our context, which the leader election code will observe and
+	// step down
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-ch
+		klog.Info("Received termination, signaling shutdown")
+		cancel()
+	}()
+
+	// we use the Lease lock type since edits to Leases are less common
+	// and fewer objects in the cluster watch "all Leases".
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      LeaseLockName,
+			Namespace: LeaseLockNamespace,
+		},
+		Client: client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+	}
+
+	// start the leader election code loop
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock: lock,
+		// IMPORTANT: you MUST ensure that any code you have that
+		// is protected by the lease must terminate **before**
+		// you call cancel. Otherwise, you could have a background
+		// loop still running and another process could
+		// get elected before your background loop finished, violating
+		// the stated goal of the lease.
+		ReleaseOnCancel: true,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				// we're notified when we start - this is where you would
+				// usually put your code
+				startedLeading.Store(true)
+				run(ctx)
+			},
+			OnStoppedLeading: func() {
+				// we can do cleanup here, but note that this callback is always called
+				// when the LeaderElector exits, even if it did not start leading.
+				// Therefore, we should check if we actually started leading before
+				// performing any cleanup operations to avoid unexpected behavior.
+				klog.Infof("leader lost: %s", id)
+
+				// Example check to ensure we only perform cleanup if we actually started leading
+				if startedLeading.Load() {
+					// Perform cleanup operations here
+					// For example, releasing resources, closing connections, etc.
+					klog.Info("Performing cleanup operations...")
+					<-end
+				} else {
+					klog.Info("No cleanup needed as we never started leading.")
+				}
+				os.Exit(0)
+			},
+			OnNewLeader: func(identity string) {
+				// we're notified when new leader elected
+				if identity == id {
+					// I just got the lock
+					return
+				}
+				klog.Infof("new leader elected: %s", identity)
+			},
+		},
+	})
+}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -15,6 +15,7 @@
 package manager
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ func TestFlow(t *testing.T) {
 	source := util.NewDummySource(batch)
 	sink := util.NewDummySink("sink", time.Millisecond)
 
-	manager, _ := NewManager(source, sink, time.Second)
+	manager, _ := NewManager(context.Background(), source, sink, time.Second)
 	manager.Start()
 
 	// 4-5 cycles

--- a/sinks/sls/sls.go
+++ b/sinks/sls/sls.go
@@ -99,6 +99,7 @@ func (s *SLSSink) ExportEvents(batch *core.EventBatch) {
 func (s *SLSSink) Stop() {
 	// safe close producer: close after all data is sent
 	s.getProducer().SafeClose()
+	klog.Info("sls producer safely closed")
 }
 
 // get a sls producer.

--- a/sources/factory.go
+++ b/sources/factory.go
@@ -15,6 +15,7 @@
 package sources
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/AliyunContainerService/kube-eventer/common/flags"
@@ -26,23 +27,23 @@ import (
 type SourceFactory struct {
 }
 
-func (this *SourceFactory) Build(uri flags.Uri, exportMetric bool) (core.EventSource, error) {
+func (this *SourceFactory) Build(ctx context.Context, uri flags.Uri, exportMetric bool) (core.EventSource, error) {
 	switch uri.Key {
 	case "kubernetes":
-		src, err := kube.NewKubernetesSource(&uri.Val, exportMetric)
+		src, err := kube.NewKubernetesSource(ctx, &uri.Val, exportMetric)
 		return src, err
 	default:
 		return nil, fmt.Errorf("Source not recognized: %s", uri.Key)
 	}
 }
 
-func (this *SourceFactory) BuildAll(uris flags.Uris, exportMetric bool) ([]core.EventSource, error) {
+func (this *SourceFactory) BuildAll(ctx context.Context, uris flags.Uris, exportMetric bool) ([]core.EventSource, error) {
 	if len(uris) != 1 {
 		return nil, fmt.Errorf("Only one source is supported")
 	}
 	result := []core.EventSource{}
 	for _, uri := range uris {
-		source, err := this.Build(uri, exportMetric)
+		source, err := this.Build(ctx, uri, exportMetric)
 		if err != nil {
 			klog.Errorf("Failed to create %s: %v", uri.Key, err)
 		} else {


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  Here are some tips for you: 
感谢你提交了 pull request ，一些 tips 供您参考：

-->

**What type of PR is this?**
**PR类型是什么？**

> /kind feature

**What this PR does / why we need it**:
**这个PR解决了什么问题**:

Implement high availability for `kube-eventer` using Leader Election.

**Does this PR introduce a breaking change?**:
**PR带来的破坏性变更**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 
如果没有，就写 NONE。引入新的外部依赖，更新已有依赖都视为"破坏性变更"
-->

NONE

**Test/Final result**:
**测试/最终运行结果**:
<!--
You can put some pictures or show your test result.
放几张图片或测试结果
-->

```Plain Text
I0217 15:40:21.294227       1 main.go:30] current replica id is 36683cbe-a642-4ee5-930e-38186ae24529
I0217 15:40:21.295222       1 leaderelection.go:242] attempting to acquire leader lease  kube-system/eventer-lease-lock...
I0217 15:41:34.104756       1 leaderelection.go:252] successfully acquired lease kube-system/eventer-lease-lock
I0217 15:41:34.104827       1 main.go:47] kube-eventer start...
I0217 15:41:34.108721       1 aliyun_util.go:193] get token by ram role.
I0217 15:41:34.109634       1 eventer.go:100] Starting with SLSSink sink
I0217 15:41:34.109661       1 eventer.go:146] Starting eventer http service
level=info time=2025-02-17T07:41:34.109567249Z caller=producer.go:251 msg="producer mover start"
I0217 15:43:00.000246       1 manager.go:102] Exporting 0 events
I0217 15:43:30.000426       1 manager.go:102] Exporting 8 events
I0217 15:43:32.134196       1 main.go:63] Received termination, signaling shutdown
I0217 15:43:32.134465       1 kubernetes_source.go:182] Event watching stopped
level=info time=2025-02-17T07:43:32.134503104Z caller=producer.go:287 msg="producer start closing"
I0217 15:43:32.134602       1 eventer.go:124] HTTP server gracefully shutdown
I0217 15:43:32.139886       1 main.go:105] leader lost: 36683cbe-a642-4ee5-930e-38186ae24529
I0217 15:43:32.139890       1 main.go:111] Performing cleanup operations...
level=info time=2025-02-17T07:43:34.001571875Z caller=mover.go:94 msg="mover thread closure complete"
level=info time=2025-02-17T07:43:34.058707519Z caller=io_thread_pool.go:66 msg="All cache tasks in the thread pool have been successfully sent"
level=info time=2025-02-17T07:43:34.058759779Z caller=producer.go:283 msg="Producer close finish"
I0217 15:43:34.058775       1 sls.go:102] sls producer safely closed
```