### PR TITLE
docs(sls-sink): document missing regionId option and self-built cluster warning

### DIFF
--- a/docs/en/sls-sink.md
+++ b/docs/en/sls-sink.md
@@ -25,7 +25,7 @@ For example:
 
     --sink=sls:https://cn-hangzhou.log.aliyuncs.com?project=my_sls_project&logStore=my_sls_project_logStore&topic=k8s-cluster-dev&regionId=cn-hangzhou&label=Key1,Value1&label=Key2,Value2
 
-For VPC/internal network access:
+For Alibaba Cloud VPC network access:
 
     --sink=sls:https://cn-hangzhou-internal.log.aliyuncs.com?project=my_sls_project&logStore=my_sls_project_logStore&topic=k8s-cluster-dev&regionId=cn-hangzhou&internal=true&label=Key1,Value1&label=Key2,Value2
 

--- a/docs/en/sls-sink.md
+++ b/docs/en/sls-sink.md
@@ -3,22 +3,42 @@
 *This sink supports sls (Log Service of Alibaba Cloud)*.
 To use the sls sink add the following flag:
 
-	--sink=sls:<SLS_ENDPOINTL>?logStore=[your_logstore]&project=[your_project]&topic=[topic_for_log]&label=<key,value>
+	--sink=sls:<SLS_ENDPOINT>?logStore=[your_logstore]&project=[your_project]&topic=[topic_for_log]&regionId=[your_region_id]&label=<key,value>
 
 
 The following options are available:
 * `project` - Project of SLS instance. 
 * `logStore` - logStore of SLS instance project. 
 * `topic` - topic for every log sent to SLS. 
+* `regionId` - **Strongly recommended for self-built (non-Alibaba Cloud managed) clusters.** The Alibaba Cloud region ID where your SLS instance resides (e.g. `cn-hangzhou`). If not set via this parameter or the `RegionId` environment variable, kube-eventer will attempt to auto-detect the region from the instance metadata service (`http://100.100.100.200/latest/meta-data/region-id`), which is unavailable in self-built clusters and will cause a startup error. Can also be configured via the `RegionId` environment variable.
 * `label` - Custom labels on alerting message.(such as clusterId), format is label=ClusterId,test_clusterId&label=RegionId,test_regionId&label=UserId,test_uid
 * `accessKeyId` - optional param. aliyun access key to sink to sls. 
 * `accessKeySecret` - optional param. aliyun access key secret to sink to sls.
 * `internal` - optional param. if true, it will sink to sls through aliyun internal network connection. 
 
+> **Note for self-built clusters:** If `regionId` is not specified and the metadata service is unreachable, kube-eventer will fail at startup with an error like:
+> `can not create sls client because of Get "http://100.100.100.200/latest/meta-data/region-id": dial tcp 100.100.100.200:80: i/o timeout`
+>
+> Always set `regionId` explicitly when running outside of Alibaba Cloud managed environments.
+
 For example:
 
-    --sink=sls:https://sls.aliyuncs.com?project=my_sls_project&logStore=my_sls_project_logStore&topic=k8s-cluster-dev&label=Key1,Value1&label=Key2,Value2
-    
+    --sink=sls:https://sls.aliyuncs.com?project=my_sls_project&logStore=my_sls_project_logStore&topic=k8s-cluster-dev&regionId=cn-hangzhou&label=Key1,Value1&label=Key2,Value2
+
+For VPC/internal network access:
+
+    --sink=sls:https://sls.aliyuncs.com?project=my_sls_project&logStore=my_sls_project_logStore&topic=k8s-cluster-dev&regionId=cn-hangzhou&internal=true&label=Key1,Value1
+
+#### How to configure regionId via environment variable.
+
+You can also set `regionId` through the `RegionId` environment variable in the kube-eventer deployment template:
+
+    env:
+     - name: RegionId
+       value: "cn-hangzhou"
+
+> Note: The environment variable name is `RegionId` (case-sensitive).
+
 #### How to config aliyun access key.
 
 *If you run kube-eventer manually, you will need to config aliyun access key to get the permission to sink your data to sls. when running on Aliyun Container Service, you don't need to config access key manually.*
@@ -27,8 +47,10 @@ You can config kube-eventer global aliyun access key through kube-eventer deploy
 
     
     env:
-     - AccessKeyId: "xxx"
-     - AccessKeySecret: "xxx"
+     - name: AccessKeyId
+       value: "xxx"
+     - name: AccessKeySecret
+       value: "xxx"
      
- 
+
  You can also config aliyun access key with sls sink optional params.

--- a/docs/en/sls-sink.md
+++ b/docs/en/sls-sink.md
@@ -10,34 +10,24 @@ The following options are available:
 * `project` - Project of SLS instance. 
 * `logStore` - logStore of SLS instance project. 
 * `topic` - topic for every log sent to SLS. 
-* `regionId` - **Strongly recommended for self-built (non-Alibaba Cloud managed) clusters.** The Alibaba Cloud region ID where your SLS instance resides (e.g. `cn-hangzhou`). If not set via this parameter or the `RegionId` environment variable, kube-eventer will attempt to auto-detect the region from the instance metadata service (`http://100.100.100.200/latest/meta-data/region-id`), which is unavailable in self-built clusters and will cause a startup error. Can also be configured via the `RegionId` environment variable.
+* `regionId` - optional param. Region of SLS instance. **Must set for self-built (non-Alibaba Cloud managed) clusters.**
 * `label` - Custom labels on alerting message.(such as clusterId), format is label=ClusterId,test_clusterId&label=RegionId,test_regionId&label=UserId,test_uid
 * `accessKeyId` - optional param. aliyun access key to sink to sls. 
 * `accessKeySecret` - optional param. aliyun access key secret to sink to sls.
 * `internal` - optional param. if true, it will sink to sls through aliyun internal network connection. 
 
-> **Note for self-built clusters:** If `regionId` is not specified and the metadata service is unreachable, kube-eventer will fail at startup with an error like:
+> **Note for self-built clusters:** If `regionId` is not specified, kube-eventer will try to get region info from the metadata service. In self-built clusters this usually fails and kube-eventer will fail at startup with an error like:
 > `can not create sls client because of Get "http://100.100.100.200/latest/meta-data/region-id": dial tcp 100.100.100.200:80: i/o timeout`
 >
 > Always set `regionId` explicitly when running outside of Alibaba Cloud managed environments.
 
 For example:
 
-    --sink=sls:https://sls.aliyuncs.com?project=my_sls_project&logStore=my_sls_project_logStore&topic=k8s-cluster-dev&regionId=cn-hangzhou&label=Key1,Value1&label=Key2,Value2
+    --sink=sls:https://cn-hangzhou.log.aliyuncs.com?project=my_sls_project&logStore=my_sls_project_logStore&topic=k8s-cluster-dev&regionId=cn-hangzhou&label=Key1,Value1&label=Key2,Value2
 
 For VPC/internal network access:
 
-    --sink=sls:https://sls.aliyuncs.com?project=my_sls_project&logStore=my_sls_project_logStore&topic=k8s-cluster-dev&regionId=cn-hangzhou&internal=true&label=Key1,Value1
-
-#### How to configure regionId via environment variable.
-
-You can also set `regionId` through the `RegionId` environment variable in the kube-eventer deployment template:
-
-    env:
-     - name: RegionId
-       value: "cn-hangzhou"
-
-> Note: The environment variable name is `RegionId` (case-sensitive).
+    --sink=sls:https://cn-hangzhou-internal.log.aliyuncs.com?project=my_sls_project&logStore=my_sls_project_logStore&topic=k8s-cluster-dev&regionId=cn-hangzhou&internal=true&label=Key1,Value1&label=Key2,Value2
 
 #### How to config aliyun access key.
 


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  Here are some tips for you: 
感谢你提交了 pull request ，一些 tips 供您参考：

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design

/kind documentation


**What this PR does / why we need it**:
This pull request updates the documentation for the SLS (Log Service of Alibaba Cloud) sink, providing clearer guidance for users deploying in both Alibaba Cloud managed and self-built environments. The main focus is on introducing and documenting the required `regionId` parameter for non-managed clusters, updating example usage, and clarifying environment variable configuration.

**Documentation improvements for SLS sink usage:**

* Added documentation for the new `regionId` parameter, explaining that it is required for self-built (non-Alibaba Cloud managed) clusters and must be set explicitly to avoid startup errors. Also included a troubleshooting note for missing `regionId`.
* Updated example sink configuration commands to include the `regionId` parameter and provided a separate example for Alibaba Cloud VPC network access.

**Configuration clarification:**

* Improved the example for setting `AccessKeyId` and `AccessKeySecret` in the environment variables, using the correct YAML format with `name` and `value` keys.

**Which issue(s) this PR fixes**:

Fixes #310 


**Does this PR introduce a breaking change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. 
-->
NONE

**Test/Final result**:
<!--
You can put some pictures or show your test result.
放几张图片或测试结果
-->